### PR TITLE
Upgrade Pravega to 0.13.0

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -16,7 +16,7 @@
         <version.pubsub>25.0.0</version.pubsub>
         <version.pulsar>2.10.1</version.pulsar>
         <version.eventhubs>5.12.1</version.eventhubs>
-        <version.pravega>0.9.1</version.pravega>
+        <version.pravega>0.13.0</version.pravega>
         <version.nats>2.16.3</version.nats>
         <version.stan>2.2.3</version.stan>
         <version.commons.logging>1.2</version.commons.logging>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -11,6 +11,8 @@
   <properties>
     <!-- IMPORTANT: This must be aligned with the netty shipped with Quarkus, specified in debezium-build-parent -->
     <netty.version>4.1.86.Final</netty.version>
+    <protobuf.version>3.21.7</protobuf.version>
+    <grpc.version>1.47.0</grpc.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -18,6 +20,20 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -34,51 +50,6 @@
       <groupId>io.pravega</groupId>
       <artifactId>pravega-client</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-socks</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -90,12 +61,6 @@
       <groupId>io.debezium</groupId>
       <artifactId>debezium-server-core</artifactId>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -131,7 +96,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>integration-test-pravega</id>
+                        <id>integration-test-pravega-0.11</id>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
@@ -140,12 +105,13 @@
                                 <debezium.sink.type>pravega</debezium.sink.type>
                                 <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
                                 <debezium.sink.pravega.transaction>false</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.11.0</pravega.docker.version>
                             </systemPropertyVariables>
                             <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>integration-test-pravega-txn</id>
+                        <id>integration-test-pravega-0.11-txn</id>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
@@ -154,6 +120,67 @@
                                 <debezium.sink.type>pravega</debezium.sink.type>
                                 <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
                                 <debezium.sink.pravega.transaction>true</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.11.0</pravega.docker.version>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-pravega-0.12</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <debezium.sink.type>pravega</debezium.sink.type>
+                                <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
+                                <debezium.sink.pravega.transaction>false</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.12.0</pravega.docker.version>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-pravega-0.12-txn</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <debezium.sink.type>pravega</debezium.sink.type>
+                                <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
+                                <debezium.sink.pravega.transaction>true</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.12.0</pravega.docker.version>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-pravega-0.13</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <debezium.sink.type>pravega</debezium.sink.type>
+                                <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
+                                <debezium.sink.pravega.transaction>false</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.13.0-rc0</pravega.docker.version>
+                            </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-pravega-0.13-txn</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <debezium.sink.type>pravega</debezium.sink.type>
+                                <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
+                                <debezium.sink.pravega.transaction>true</debezium.sink.pravega.transaction>
+                                <pravega.docker.version>0.13.0-rc0</pravega.docker.version>
                             </systemPropertyVariables>
                             <runOrder>${runOrder}</runOrder>
                         </configuration>

--- a/debezium-server-pravega/src/test/java/io/debezium/server/pravega/PravegaTestResource.java
+++ b/debezium-server-pravega/src/test/java/io/debezium/server/pravega/PravegaTestResource.java
@@ -28,7 +28,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
  */
 public class PravegaTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String PRAVEGA_VERSION = "0.9.0";
+    private static final String PRAVEGA_VERSION = ConfigProvider.getConfig().getValue("pravega.docker.version", String.class);
     public static final int CONTROLLER_PORT = 9090;
     public static final int SEGMENT_STORE_PORT = 12345;
     public static final String PRAVEGA_IMAGE = "pravega/pravega:" + PRAVEGA_VERSION;
@@ -38,7 +38,7 @@ public class PravegaTestResource implements QuarkusTestResourceLifecycleManager 
             .withFixedExposedPort(CONTROLLER_PORT, CONTROLLER_PORT)
             .withFixedExposedPort(SEGMENT_STORE_PORT, SEGMENT_STORE_PORT)
             .withStartupTimeout(Duration.ofSeconds(90))
-            .waitingFor(Wait.forLogMessage(".*Starting gRPC server listening on port: 9090.*", 1))
+            .waitingFor(Wait.forLogMessage(".*Pravega Sandbox is running locally now.*", 1))
             .withCommand("standalone");
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
 
     <repositories>
         <repository>
+            <id>v0.13.0-rc0</id>
+            <url>https://oss.sonatype.org/content/repositories/iopravega-1206</url>
+        </repository>
+        <repository>
             <id>oss</id>
             <name>OSS Sonatype Nexus</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>


### PR DESCRIPTION
Upgrade debezium-server-pravega to use Pravega 0.13.0

- [x] Upgrade to 0.13.0-rc0
- [x] Run integration test against compatible Pravega servers (0.11, 0.12, 0.13)
- [ ] Document Pravega connector in README.md
- [ ] Use final 0.13.0 release, remove staging repository