### PR TITLE
DBZ-6319 Async producer for Pulsar sink

### DIFF
--- a/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
+++ b/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
@@ -148,21 +148,22 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
 
             final ChangeEvent<Object, Object> currentRecord = record;
 
-            CompletableFuture<MessageId> future = message.sendAsync()
-                    .thenAccept(messageId -> {
-                        LOGGER.trace("Sent message with id: {}", messageId);
-                        try {
-                            committer.markProcessed(currentRecord);
-                        }
-                        catch (InterruptedException e) {
-                            throw new DebeziumException(e);
-                        }
-                    })
-                    .exceptionally(ex -> {
-                        Throwable exception = (Throwable) ex;
-                        LOGGER.error("Failed to send record to {}:", record.destination(), exception);
-                        throw new DebeziumException(exception);
-                    });
+            CompletableFuture<MessageId> future = message
+                .sendAsync()
+                .thenAccept(messageId -> {
+                    LOGGER.trace("Sent message with id: {}", messageId);
+                    try {
+                        committer.markProcessed(currentRecord);
+                    }
+                    catch (InterruptedException e) {
+                        throw new DebeziumException(e);
+                    }
+                })
+                .exceptionally(ex -> {
+                    Throwable exception = (Throwable) ex;
+                    LOGGER.error("Failed to send record to {}:", record.destination(), exception);
+                    throw new DebeziumException(exception);
+                });
 
             futures.add(future);
         }
@@ -170,8 +171,8 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
         try {
             // Wait for all CompletableFutures to complete
             CompletableFuture
-                    .allOf(futures.toArray(new CompletableFuture[0]))
-                    .join();
+                .allOf(futures.toArray(new CompletableFuture[0]))
+                .join();
         }
         catch (CompletionException e) {
             if (e.getCause() instanceof DebeziumException) {

--- a/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
+++ b/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
@@ -149,11 +149,10 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
             final ChangeEvent<Object, Object> currentRecord = record;
 
             CompletableFuture<MessageId> future = message.sendAsync()
-                    .thenApply(messageId -> {
+                    .thenAccept(messageId -> {
                         LOGGER.trace("Sent message with id: {}", messageId);
                         try {
                             committer.markProcessed(currentRecord);
-                            return messageId;
                         }
                         catch (InterruptedException e) {
                             throw new DebeziumException(e);


### PR DESCRIPTION
We have experienced very low performance using the current pulsar sink implementation. The root cause seems to be that it uses the synchronous `send` method and it waits for every single message to be delivered and written to pulsar before trying to send the next one. 

For much better message rate it is recommended to use `sendAsync` for the items in the batch and wait all of them to complete before marking the batch finished.

Real debezium performance measurements:
* sending messages one-by-one using `send` on my m1 macbook pro: `~600 msg/sec`
* sending messages in batches using `sendAsync` on my m1 macbook pro: `~70000 msg/sec`

Measured reate using pulsar-perf cli tool.