### PR TITLE
DBZ-6348 Add JWT authentication to HTTP Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The application itself contains the `core` module and a set of modules responsib
 The following software is required to work with the Debezium codebase and build it locally:
 
 * [Git](https://git-scm.com) 2.2.1 or later
-* JDK 17 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* JDK 11 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
 * [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 * [Apache Maven](https://maven.apache.org/index.html) 3.8.4 or later  
   (or invoke the wrapper with `./mvnw` for Maven commands)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,57 @@
 
 Debezium Server is a standalone Java application built on Qurkus framework.
 The application itself contains the `core` module and a set of modules responsible for communication with different target systems.
+## Building and Packaging
+
+The following software is required to work with the Debezium codebase and build it locally:
+
+* [Git](https://git-scm.com) 2.2.1 or later
+* JDK 17 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
+* [Apache Maven](https://maven.apache.org/index.html) 3.8.4 or later  
+  (or invoke the wrapper with `./mvnw` for Maven commands)
+
+See the links above for installation instructions on your platform. You can verify the versions are installed and running:
+
+    $ git --version
+    $ javac -version
+    $ mvn -version
+
+### Building the code
+
+Debezium Server depends on core Debezium.  You'll need to install the most recent snapshot locally. First obtain the code by cloning the Git repository:
+
+    $ git clone https://github.com/debezium/debezium.git
+    $ cd debezium
+
+Then build the code using Maven:
+
+    $ mvn clean install -DskipITs -DskipTests
+
+Then, you can build Debezium Server:
+
+    $ git clone https://github.com/debezium/debezium-server.git
+    $ cd debezium-server
+    $ mvn clean install -DskipITs -DskipTests
+
+### Creating a Distribution
+
+Debezium Server is normally run by downloading the distribution tar.gz or zip file.  You can generate this file by:
+
+    $ mvn clean package -DskipITs -DskipTests -Passembly
+
+The archives can be found under `debezium-server-dist/target`.
+
+### Building just the artifacts, without running tests, CheckStyle, etc.
+
+You can skip all non-essential plug-ins (tests, integration tests, CheckStyle, formatter, API compatibility check, etc.) using the "quick" build profile:
+
+    $ mvn clean verify -Dquick
+
+This provides the fastest way for solely producing the output artifacts, without running any of the QA related Maven plug-ins.
+This comes in handy for producing connector JARs and/or archives as quickly as possible, e.g. for manual testing in Kafka Connect
+
+## Integration Tests
 
 The per-module integration tests depend on the availability of the external services.
 It is thus recommended to execute integration tests per-module and set-up necessary pre-requisities beforehand.
@@ -9,19 +60,19 @@ It is thus recommended to execute integration tests per-module and set-up necess
 Note: running these tests against external infrastructure may incur cost with your cloud provider.
 We're not going to pay your AWS/GCP/Azure bill.
 
-## Amazon Kinesis
+### Amazon Kinesis
 
 * Execute `aws configure` as described in AWS CLI [getting started](https://github.com/aws/aws-cli#getting-started) guide and setup the account.
 * Create Kinesis stream `aws kinesis create-stream --stream-name testc.inventory.customers --shard-count 1`
 * Build the module and execute the tests `mvn clean install -DskipITs=false -am -pl debezium-server-kinesis`
 * Remove the stream `aws kinesis delete-stream --stream-name testc.inventory.customers`
 
-## Google Cloud Pub/Sub
+### Google Cloud Pub/Sub
 
 * Login into your Google Cloud account using `gcloud auth application-default login` as described in the [documentation](https://cloud.google.com/sdk/gcloud/reference/auth/application-default).
 * Build the module and execute the tests `mvn clean install -DskipITs=false -am -pl debezium-server-pubsub`
 
-## Azure Event Hubs
+### Azure Event Hubs
 
 Login into your Azure account and create a resource group, e.g. on the CLI:
 

--- a/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+
+public interface Authenticator {
+    void addAuthorizationHeader(HttpRequest.Builder httpRequestBuilder);
+
+    boolean authenticate() throws InterruptedException, IOException;
+}

--- a/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
@@ -5,11 +5,10 @@
  */
 package io.debezium.server.http;
 
-import java.io.IOException;
 import java.net.http.HttpRequest;
 
 public interface Authenticator {
     void addAuthorizationHeader(HttpRequest.Builder httpRequestBuilder);
 
-    boolean authenticate() throws InterruptedException, IOException;
+    boolean authenticate() throws InterruptedException;
 }

--- a/debezium-server-http/src/main/java/io/debezium/server/http/HttpChangeConsumer.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/HttpChangeConsumer.java
@@ -89,7 +89,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
     }
 
     @VisibleForTesting
-    void initWithConfig(Config config) throws URISyntaxException, IllegalArgumentException, URISyntaxException {
+    void initWithConfig(Config config) throws URISyntaxException {
         String sinkUrl;
         String contentType;
 
@@ -143,9 +143,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
                 authenticator = builder.build();
             }
             else {
-                String msg = "Unknown value '" + t + "' encountered for property " + PROP_AUTHENTICATION_PREFIX + PROP_AUTHENTICATION_TYPE;
-                LOGGER.error(msg);
-                throw new IllegalArgumentException(msg);
+                throw new DebeziumException("Unknown value '" + t + "' encountered for property " + PROP_AUTHENTICATION_PREFIX + PROP_AUTHENTICATION_TYPE);
             }
         }
 
@@ -157,7 +155,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
 
     @Override
     public void handleBatch(List<ChangeEvent<Object, Object>> records, DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer)
-            throws InterruptedException, IllegalStateException {
+            throws InterruptedException {
         for (ChangeEvent<Object, Object> record : records) {
             LOGGER.trace("Received event '{}'", record);
 
@@ -177,7 +175,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
         committer.markBatchFinished();
     }
 
-    private boolean recordSent(ChangeEvent<Object, Object> record) throws InterruptedException, IllegalStateException {
+    private boolean recordSent(ChangeEvent<Object, Object> record) throws InterruptedException {
         boolean sent = false;
         HttpResponse<String> r;
 
@@ -186,9 +184,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
         try {
             if (authenticator != null) {
                 if (!authenticator.authenticate()) {
-                    String msg = "Failed to authenticate successfully.  Cannot continue.";
-                    LOGGER.error(msg);
-                    throw new IllegalStateException(msg);
+                    throw new DebeziumException("Failed to authenticate successfully.  Cannot continue.");
                 }
                 authenticator.addAuthorizationHeader(requestBuilder);
             }

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.annotation.VisibleForTesting;
+import io.debezium.server.http.Authenticator;
+
+/**
+ * Implements the logic for authenticating against an endpoint supporting the
+ * JSON Web Tokens (JWT) scheme.  Once authentication is successful, the
+ * authenticator can add the authentication details to the header of an HTTP
+ * request using a <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html">HTTPRequest.Builder</a> instance. After the initial authentication
+ * is successful, additional authentication attempts will refresh the token.
+ */
+public class JWTAuthenticator implements Authenticator {
+    private enum AuthenticationState {
+        NOT_AUTHENTICATED, // before first successful authentication
+        FAILED_AUTHENTICATION, // attempted authentication but it failed
+        ACTIVE, // successful authentication and token is still valid
+        EXPIRED // successful authentication but token has expired
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JWTAuthenticator.class);
+
+    // Want to authenticate before expiration
+    private static final double EXPIRATION_DURATION_MULTIPLIER = 0.9;
+
+    private final String username;
+    private final String password;
+    private final long tokenExpirationDuration; // minutes
+    private final long refreshTokenExpirationDuration; // minutes
+
+    private String jwtToken;
+    private String jwtRefreshToken;
+    private final HttpClient client;
+    private final HttpRequest.Builder authRequestBuilder;
+    private final HttpRequest.Builder refreshRequestBuilder;
+    private final ObjectMapper mapper;
+
+    private AuthenticationState authenticationState;
+    private DateTime expirationDateTime;
+
+    JWTAuthenticator(URI authUri, URI refreshUri, String username, String password, long tokenExpirationDuration, long refreshTokenExpirationDuration,
+                     Duration httpTimeoutDuration) {
+        this.username = username;
+        this.password = password;
+        this.tokenExpirationDuration = tokenExpirationDuration;
+        this.refreshTokenExpirationDuration = refreshTokenExpirationDuration;
+
+        mapper = new ObjectMapper();
+        client = HttpClient.newHttpClient();
+        authRequestBuilder = HttpRequest.newBuilder(authUri).timeout(httpTimeoutDuration);
+        authRequestBuilder.setHeader("content-type", "application/json");
+        refreshRequestBuilder = HttpRequest.newBuilder(refreshUri).timeout(httpTimeoutDuration);
+        refreshRequestBuilder.setHeader("content-type", "application/json");
+
+        authenticationState = AuthenticationState.NOT_AUTHENTICATED;
+        // initialize to value before now to correspond to not authenticated state
+        expirationDateTime = DateTime.now().minusDays(1);
+    }
+
+    @VisibleForTesting
+    HttpRequest generateInitialAuthenticationRequest() throws IOException {
+        JWTAuthorizationInitialRequest payload = new JWTAuthorizationInitialRequest(username, password, tokenExpirationDuration, refreshTokenExpirationDuration);
+
+        StringWriter payloadWriter = new StringWriter();
+        try {
+            mapper.writeValue(payloadWriter, payload);
+        }
+        catch (IOException e) {
+            LOGGER.error("Could not serialize JWTAuthorizationRequest object to JSON.");
+            throw e;
+        }
+
+        String payloadJSON = payloadWriter.toString();
+        HttpRequest.Builder builder = authRequestBuilder.POST(HttpRequest.BodyPublishers.ofString(payloadJSON));
+
+        return builder.build();
+    }
+
+    private void checkAuthenticationExpired() {
+        if (authenticationState == AuthenticationState.ACTIVE) {
+            if (expirationDateTime.isBeforeNow()) {
+                authenticationState = AuthenticationState.EXPIRED;
+            }
+        }
+    }
+
+    @VisibleForTesting
+    HttpRequest generateRefreshAuthenticationRequest() throws IOException {
+        checkAuthenticationExpired();
+
+        if (authenticationState == AuthenticationState.NOT_AUTHENTICATED || authenticationState == AuthenticationState.FAILED_AUTHENTICATION) {
+            String msg = "Must perform initial authentication successfully before attempting to refresh authentication";
+            LOGGER.error(msg);
+            throw new IllegalStateException(msg);
+        }
+
+        JWTAuthorizationRefreshRequest payload = new JWTAuthorizationRefreshRequest(jwtRefreshToken, tokenExpirationDuration, refreshTokenExpirationDuration);
+
+        StringWriter payloadWriter = new StringWriter();
+        try {
+            mapper.writeValue(payloadWriter, payload);
+        }
+        catch (IOException e) {
+            LOGGER.error("Could not serialize JWTAuthorizationRequest object to JSON.");
+            throw e;
+        }
+
+        String payloadJSON = payloadWriter.toString();
+        HttpRequest.Builder builder = authRequestBuilder.POST(HttpRequest.BodyPublishers.ofString(payloadJSON));
+
+        return builder.build();
+    }
+
+    public void addAuthorizationHeader(HttpRequest.Builder httpRequestBuilder) {
+        checkAuthenticationExpired();
+        if (authenticationState == AuthenticationState.NOT_AUTHENTICATED || authenticationState == AuthenticationState.FAILED_AUTHENTICATION) {
+            String msg = "Must successfully authenticate against JWT endpoint before you can add the authorization information to the HTTP header.";
+            LOGGER.error(msg);
+            throw new IllegalStateException(msg);
+        }
+        else if (authenticationState == AuthenticationState.EXPIRED) {
+            String msg = "JWT authentication is expired. Must renew authentication before you can add the authorization information to the HTTP header.";
+            LOGGER.error(msg);
+            throw new IllegalStateException(msg);
+        }
+
+        httpRequestBuilder.header("Authorization", "Bearer: " + jwtToken);
+    }
+
+    public boolean authenticate() throws InterruptedException, IOException {
+        checkAuthenticationExpired();
+
+        HttpResponse<String> r;
+        HttpRequest request;
+        JWTAuthorizationResponse response;
+
+        if (authenticationState == AuthenticationState.ACTIVE) {
+            return true;
+        }
+        else if (authenticationState == AuthenticationState.NOT_AUTHENTICATED || authenticationState == AuthenticationState.FAILED_AUTHENTICATION) {
+            request = generateInitialAuthenticationRequest();
+        }
+        else if (authenticationState == AuthenticationState.EXPIRED) {
+            request = generateRefreshAuthenticationRequest();
+        }
+        else {
+            // we should never get here...
+            String msg = "Reached invalid authentication state.";
+            LOGGER.error(msg);
+            throw new IllegalStateException(msg);
+        }
+
+        try {
+            r = client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (IOException ioe) {
+            throw new InterruptedException(ioe.toString());
+        }
+
+        if (r.statusCode() == HTTP_OK) {
+            String responseBody = r.body();
+
+            try {
+                response = mapper.readValue(responseBody, JWTAuthorizationResponse.class);
+            }
+            catch (IOException e) {
+                LOGGER.error("Could not deserialize JWT authorization response.");
+                throw e;
+            }
+
+            jwtToken = response.getJwt();
+            jwtRefreshToken = response.getJwtRefreshToken();
+
+            // in ms
+            long expirationDuration = (long) (EXPIRATION_DURATION_MULTIPLIER * response.getExpiresIn());
+            expirationDateTime = DateTime.now().plus(expirationDuration);
+
+            authenticationState = AuthenticationState.ACTIVE;
+
+            return true;
+        }
+
+        authenticationState = AuthenticationState.FAILED_AUTHENTICATION;
+        LOGGER.error("JWT Authentication failure. Check credentials.");
+
+        return false;
+    }
+}

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
@@ -33,7 +33,8 @@ import io.debezium.server.http.Authenticator;
  * is successful, additional authentication attempts will refresh the token.
  */
 public class JWTAuthenticator implements Authenticator {
-    private enum AuthenticationState {
+    @VisibleForTesting
+    enum AuthenticationState {
         NOT_AUTHENTICATED, // before first successful authentication
         FAILED_AUTHENTICATION, // attempted authentication but it failed
         ACTIVE, // successful authentication and token is still valid
@@ -77,6 +78,21 @@ public class JWTAuthenticator implements Authenticator {
         authenticationState = AuthenticationState.NOT_AUTHENTICATED;
         // initialize to value before now to correspond to not authenticated state
         expirationDateTime = DateTime.now().minusDays(1);
+    }
+
+    @VisibleForTesting
+    void setAuthenticationState(AuthenticationState state) {
+        this.authenticationState = state;
+    }
+
+    @VisibleForTesting
+    void setJwtToken(String token) {
+        this.jwtToken = token;
+    }
+
+    @VisibleForTesting
+    void setJwtRefreshToken(String token) {
+        this.jwtRefreshToken = token;
     }
 
     @VisibleForTesting

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
@@ -108,7 +108,13 @@ public class JWTAuthenticatorBuilder {
 
     public JWTAuthenticator build() {
         if (authUri == null) {
-            String msg = "Cannot build JWTAuthenticator.  Uri must be set.";
+            String msg = "Cannot build JWTAuthenticator.  Initialization authorization URI must be set.";
+            LOGGER.error(msg);
+            throw new NoSuchElementException(msg);
+        }
+
+        if (refreshUri == null) {
+            String msg = "Cannot build JWTAuthenticator.  Refresh authorization URI must be set.";
             LOGGER.error(msg);
             throw new NoSuchElementException(msg);
         }

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
@@ -14,6 +14,8 @@ import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
+
 public class JWTAuthenticatorBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(JWTAuthenticatorBuilder.class);
     private static final long HTTP_TIMEOUT = Integer.toUnsignedLong(60000); // Default to 60s
@@ -35,7 +37,7 @@ public class JWTAuthenticatorBuilder {
     private long refreshTokenExpirationDuration = Integer.toUnsignedLong(60 * 24); // Default to 24 hours
     private Duration httpTimeoutDuration = Duration.ofMillis(HTTP_TIMEOUT); // in ms
 
-    public static JWTAuthenticatorBuilder fromConfig(Config config, String prop_prefix) throws URISyntaxException {
+    public static JWTAuthenticatorBuilder fromConfig(Config config, String prop_prefix) {
         JWTAuthenticatorBuilder builder = new JWTAuthenticatorBuilder();
 
         builder.setUsername(config.getValue(prop_prefix + PROP_USERNAME, String.class));
@@ -49,8 +51,7 @@ public class JWTAuthenticatorBuilder {
             builder.setAuthUri(authUri);
         }
         catch (URISyntaxException e) {
-            LOGGER.error("Could not parse authentication URL: " + uriString + AUTHENTICATE_PATH);
-            throw e;
+            throw new DebeziumException("Could not parse authentication URL: " + uriString + AUTHENTICATE_PATH, e);
         }
 
         try {
@@ -59,8 +60,7 @@ public class JWTAuthenticatorBuilder {
             builder.setRefreshUri(refreshUri);
         }
         catch (URISyntaxException e) {
-            LOGGER.error("Could not parse refresh URL: " + uriString + REFRESH_PATH);
-            throw e;
+            throw new DebeziumException("Could not parse refresh URL: " + uriString + REFRESH_PATH, e);
         }
 
         config.getOptionalValue(prop_prefix + PROP_TOKEN_EXPIRATION, Long.class)

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+
+import org.eclipse.microprofile.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JWTAuthenticatorBuilder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JWTAuthenticatorBuilder.class);
+    private static final long HTTP_TIMEOUT = Integer.toUnsignedLong(60000); // Default to 60s
+
+    private static final String PROP_USERNAME = "jwt.username";
+    private static final String PROP_PASSWORD = "jwt.password";
+    private static final String PROP_URL = "jwt.url";
+    private static final String PROP_TOKEN_EXPIRATION = "jwt.token_expiration";
+    private static final String PROP_RENEW_TOKEN_EXPIRATION = "jwt.refresh_token_expiration";
+
+    private static final String AUTHENTICATE_PATH = "auth/authenticate";
+    private static final String REFRESH_PATH = "auth/refreshToken";
+
+    private URI authUri;
+    private URI refreshUri;
+    private String username;
+    private String password;
+    private long tokenExpirationDuration = Integer.toUnsignedLong(60); // Default to 60 min
+    private long refreshTokenExpirationDuration = Integer.toUnsignedLong(60 * 24); // Default to 24 hours
+    private Duration httpTimeoutDuration = Duration.ofMillis(HTTP_TIMEOUT); // in ms
+
+    public static JWTAuthenticatorBuilder fromConfig(Config config, String prop_prefix) throws URISyntaxException {
+        JWTAuthenticatorBuilder builder = new JWTAuthenticatorBuilder();
+
+        builder.setUsername(config.getValue(prop_prefix + PROP_USERNAME, String.class));
+        builder.setPassword(config.getValue(prop_prefix + PROP_PASSWORD, String.class));
+
+        String uriString = config.getValue(prop_prefix + PROP_URL, String.class);
+
+        try {
+            LOGGER.info("Authentication URL is " + uriString + AUTHENTICATE_PATH);
+            URI authUri = new URI(uriString + AUTHENTICATE_PATH);
+            builder.setAuthUri(authUri);
+        }
+        catch (URISyntaxException e) {
+            LOGGER.error("Could not parse authentication URL: " + uriString + AUTHENTICATE_PATH);
+            throw e;
+        }
+
+        try {
+            LOGGER.info("Authentication URL is " + uriString + REFRESH_PATH);
+            URI refreshUri = new URI(uriString + REFRESH_PATH);
+            builder.setRefreshUri(refreshUri);
+        }
+        catch (URISyntaxException e) {
+            LOGGER.error("Could not parse refresh URL: " + uriString + REFRESH_PATH);
+            throw e;
+        }
+
+        config.getOptionalValue(prop_prefix + PROP_TOKEN_EXPIRATION, Long.class)
+                .ifPresent(builder::setTokenExpirationDuration);
+
+        config.getOptionalValue(prop_prefix + PROP_RENEW_TOKEN_EXPIRATION, Long.class)
+                .ifPresent(builder::setRefreshTokenExpirationDuration);
+
+        return builder;
+    }
+
+    public void setRefreshUri(URI refreshUri) {
+        this.refreshUri = refreshUri;
+    }
+
+    public JWTAuthenticatorBuilder setAuthUri(URI authUri) {
+        this.authUri = authUri;
+        return this;
+    }
+
+    public JWTAuthenticatorBuilder setUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public JWTAuthenticatorBuilder setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public JWTAuthenticatorBuilder setTokenExpirationDuration(long tokenExpirationDuration) {
+        this.tokenExpirationDuration = tokenExpirationDuration;
+        return this;
+    }
+
+    public JWTAuthenticatorBuilder setRefreshTokenExpirationDuration(long refreshTokenExpirationDuration) {
+        this.refreshTokenExpirationDuration = refreshTokenExpirationDuration;
+        return this;
+    }
+
+    public JWTAuthenticatorBuilder setHttpTimeoutDuration(long timeoutDuration) {
+        this.httpTimeoutDuration = Duration.ofMillis(timeoutDuration);
+        return this;
+    }
+
+    public JWTAuthenticator build() {
+        if (authUri == null) {
+            String msg = "Cannot build JWTAuthenticator.  Uri must be set.";
+            LOGGER.error(msg);
+            throw new NoSuchElementException(msg);
+        }
+
+        if (username == null) {
+            String msg = "Cannot build JWTAuthenticator.  Username must be set.";
+            LOGGER.error(msg);
+            throw new NoSuchElementException(msg);
+        }
+
+        if (password == null) {
+            String msg = "Cannot build JWTAuthenticator.  Password must be set.";
+            LOGGER.error(msg);
+            throw new NoSuchElementException(msg);
+        }
+
+        return new JWTAuthenticator(authUri, refreshUri, username, password, tokenExpirationDuration, refreshTokenExpirationDuration, httpTimeoutDuration);
+    }
+}

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationInitialRequest.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationInitialRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JWTAuthorizationInitialRequest {
+    private String username;
+    private String password;
+    private long tokenExpiryInMinutes;
+    private long refreshTokenExpiryInMinutes;
+
+    public JWTAuthorizationInitialRequest() {
+
+    }
+
+    public JWTAuthorizationInitialRequest(String username, String password, long tokenExpiryInMinutes, long refreshTokenExpiryInMinutes) {
+        this.username = username;
+        this.password = password;
+        this.tokenExpiryInMinutes = tokenExpiryInMinutes;
+        this.refreshTokenExpiryInMinutes = refreshTokenExpiryInMinutes;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public long getTokenExpiryInMinutes() {
+        return tokenExpiryInMinutes;
+    }
+
+    public void setTokenExpiryInMinutes(long tokenExpiryInMinutes) {
+        this.tokenExpiryInMinutes = tokenExpiryInMinutes;
+    }
+
+    public long getRefreshTokenExpiryInMinutes() {
+        return refreshTokenExpiryInMinutes;
+    }
+
+    public void setRefreshTokenExpiryInMinutes(long refreshTokenExpiryInMinutes) {
+        this.refreshTokenExpiryInMinutes = refreshTokenExpiryInMinutes;
+    }
+}

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationRefreshRequest.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationRefreshRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JWTAuthorizationRefreshRequest {
+    private String jwtRefreshToken;
+    private long tokenExpiryInMinutes;
+    private long refreshTokenExpiryInMinutes;
+
+    public JWTAuthorizationRefreshRequest() {
+
+    }
+
+    public JWTAuthorizationRefreshRequest(String jwtRefreshToken, long tokenExpiryInMinutes, long refreshTokenExpiryInMinutes) {
+        this.jwtRefreshToken = jwtRefreshToken;
+        this.tokenExpiryInMinutes = tokenExpiryInMinutes;
+        this.refreshTokenExpiryInMinutes = refreshTokenExpiryInMinutes;
+    }
+
+    public String getJwtRefreshToken() {
+        return jwtRefreshToken;
+    }
+
+    public void setJwtRefreshToken(String jwtRefreshToken) {
+        this.jwtRefreshToken = jwtRefreshToken;
+    }
+
+    public long getTokenExpiryInMinutes() {
+        return tokenExpiryInMinutes;
+    }
+
+    public void setTokenExpiryInMinutes(long tokenExpiryInMinutes) {
+        this.tokenExpiryInMinutes = tokenExpiryInMinutes;
+    }
+
+    public long getRefreshTokenExpiryInMinutes() {
+        return refreshTokenExpiryInMinutes;
+    }
+
+    public void setRefreshTokenExpiryInMinutes(long refreshTokenExpiryInMinutes) {
+        this.refreshTokenExpiryInMinutes = refreshTokenExpiryInMinutes;
+    }
+}

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationResponse.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthorizationResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JWTAuthorizationResponse {
+    private long expiresIn;
+    private String jwt;
+    private String jwtRefreshToken;
+    private long refreshTokenExpiresIn;
+
+    public JWTAuthorizationResponse() {
+
+    }
+
+    public JWTAuthorizationResponse(long expiresIn, String jwt, String jwtRefreshToken, long refreshTokenExpiresIn) {
+        this.expiresIn = expiresIn;
+        this.jwt = jwt;
+        this.jwtRefreshToken = jwtRefreshToken;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+
+    public long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(long expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public String getJwt() {
+        return jwt;
+    }
+
+    public void setJwt(String jwt) {
+        this.jwt = jwt;
+    }
+
+    public String getJwtRefreshToken() {
+        return jwtRefreshToken;
+    }
+
+    public void setJwtRefreshToken(String jwtRefreshToken) {
+        this.jwtRefreshToken = jwtRefreshToken;
+    }
+
+    public long getRefreshTokenExpiresIn() {
+        return refreshTokenExpiresIn;
+    }
+
+    public void setRefreshTokenExpiresIn(long refreshTokenExpiresIn) {
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+}

--- a/debezium-server-http/src/test/java/io/debezium/server/http/HttpChangeConsumerTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/HttpChangeConsumerTest.java
@@ -31,7 +31,7 @@ public class HttpChangeConsumerTest {
         changeConsumer.initWithConfig(generateMockConfig(Map.of(
                 HttpChangeConsumer.PROP_PREFIX + HttpChangeConsumer.PROP_WEBHOOK_URL, "http://url",
                 "debezium.format.value", "avro")));
-        HttpRequest request = changeConsumer.generateRequest(createChangeEvent());
+        HttpRequest request = changeConsumer.generateRequest(createChangeEvent()).build();
 
         String value = request.headers().firstValue("X-DEBEZIUM-h1key").orElse(null);
         assertEquals("aDFWYWx1ZQ==", value);
@@ -44,7 +44,7 @@ public class HttpChangeConsumerTest {
                 HttpChangeConsumer.PROP_PREFIX + HttpChangeConsumer.PROP_HEADERS_ENCODE_BASE64, false,
                 HttpChangeConsumer.PROP_PREFIX + HttpChangeConsumer.PROP_WEBHOOK_URL, "http://url",
                 "debezium.format.value", "avro")));
-        HttpRequest request = changeConsumer.generateRequest(createChangeEvent());
+        HttpRequest request = changeConsumer.generateRequest(createChangeEvent()).build();
 
         String value = request.headers().firstValue("X-DEBEZIUM-h1key").orElse(null);
         assertEquals("h1Value", value);
@@ -58,7 +58,7 @@ public class HttpChangeConsumerTest {
                 HttpChangeConsumer.PROP_PREFIX + HttpChangeConsumer.PROP_HEADERS_PREFIX, "XYZ-DBZ-",
                 HttpChangeConsumer.PROP_PREFIX + HttpChangeConsumer.PROP_WEBHOOK_URL, "http://url",
                 "debezium.format.value", "avro")));
-        HttpRequest request = changeConsumer.generateRequest(createChangeEvent());
+        HttpRequest request = changeConsumer.generateRequest(createChangeEvent()).build();
 
         String value = request.headers().firstValue("XYZ-DBZ-h1key").orElse(null);
         assertEquals("h1Value", value);

--- a/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilderTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+public class JWTAuthenticatorBuilderTest {
+
+    @Test
+    public void verifyBuild() throws URISyntaxException {
+        JWTAuthenticatorBuilder builder = new JWTAuthenticatorBuilder();
+        builder.setRefreshUri(new URI("http://test.com"));
+        builder.setUsername("testUser");
+        builder.setPassword("testPassword");
+
+        JWTAuthenticator authenticator = builder.build();
+    }
+
+    @Test
+    public void verifyBuildFromConfig() throws URISyntaxException {
+        Map<String, Object> configValues = Map.of("debezium.sink.http.jwt.url", "http://test.com/",
+                "debezium.sink.http.jwt.username", "testUser",
+                "debezium.sink.http.jwt.password", "testPassword");
+
+        Config result = mock(Config.class);
+
+        for (Map.Entry<String, Object> entry : configValues.entrySet()) {
+            Object value = entry.getValue();
+            when(result.getValue(eq(entry.getKey()), any())).thenReturn(value);
+            when(result.getOptionalValue(eq(entry.getKey()), any())).thenReturn(Optional.of(value));
+        }
+
+        JWTAuthenticatorBuilder builder = JWTAuthenticatorBuilder.fromConfig(result, "debezium.sink.http.");
+        builder.setRefreshUri(new URI("http://test.com"));
+        builder.setUsername("testUser");
+        builder.setPassword("testPassword");
+
+        JWTAuthenticator authenticator = builder.build();
+    }
+}

--- a/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilderTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorBuilderTest.java
@@ -23,7 +23,8 @@ public class JWTAuthenticatorBuilderTest {
     @Test
     public void verifyBuild() throws URISyntaxException {
         JWTAuthenticatorBuilder builder = new JWTAuthenticatorBuilder();
-        builder.setRefreshUri(new URI("http://test.com"));
+        builder.setAuthUri(new URI("http://test.com/auth/authenticate"));
+        builder.setRefreshUri(new URI("http://test.com/auth/refreshToken"));
         builder.setUsername("testUser");
         builder.setPassword("testPassword");
 

--- a/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
@@ -50,6 +50,7 @@ public class JWTAuthenticatorTest {
                 Duration.ofMillis(100000));
 
         authenticator.setJwtToken("fakeToken");
+        authenticator.setJwtRefreshToken("fakeRefreshToken");
         authenticator.setAuthenticationState(JWTAuthenticator.AuthenticationState.EXPIRED);
 
         HttpRequest initialRequest = authenticator.generateRefreshAuthenticationRequest();
@@ -86,6 +87,6 @@ public class JWTAuthenticatorTest {
         HttpRequest initialRequest = authenticator.generateInitialAuthenticationRequest();
 
         Assertions.assertTrue(authValue.isPresent());
-        Assertions.assertTrue(authValue.get().startsWith("Bearer: "));
+        Assertions.assertEquals(authValue.get(), "Bearer: fakeToken");
     }
 }

--- a/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.http.jwt;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class JWTAuthenticatorTest {
+
+    @Test
+    public void generateInitialAuthenticationRequest() throws URISyntaxException {
+        URI authURI = new URI("http://test.com/auth/authenticate");
+        URI refreshURI = new URI("http://test.com/auth/refreshToken");
+        JWTAuthenticator authenticator = new JWTAuthenticator(authURI,
+                refreshURI,
+                "testUser",
+                "testPassword",
+                10000,
+                10000,
+                Duration.ofMillis(100000));
+
+        HttpRequest initialRequest = authenticator.generateInitialAuthenticationRequest();
+
+        Assertions.assertEquals(initialRequest.uri(),
+                authURI);
+        Assertions.assertTrue(initialRequest.method().equalsIgnoreCase("POST"));
+        Assertions.assertTrue(initialRequest.bodyPublisher().isPresent());
+    }
+
+    @Test
+    public void generateRefreshAuthenticationRequest() throws URISyntaxException {
+        URI authURI = new URI("http://test.com/auth/authenticate");
+        URI refreshURI = new URI("http://test.com/auth/refreshToken");
+        JWTAuthenticator authenticator = new JWTAuthenticator(authURI,
+                refreshURI,
+                "testUser",
+                "testPassword",
+                10000,
+                10000,
+                Duration.ofMillis(100000));
+
+        authenticator.setJwtToken("fakeToken");
+        authenticator.setAuthenticationState(JWTAuthenticator.AuthenticationState.EXPIRED);
+
+        HttpRequest initialRequest = authenticator.generateRefreshAuthenticationRequest();
+
+        Assertions.assertEquals(initialRequest.uri(),
+                refreshURI);
+        Assertions.assertTrue(initialRequest.method().equalsIgnoreCase("POST"));
+        Assertions.assertTrue(initialRequest.bodyPublisher().isPresent());
+    }
+
+    @Test
+    public void addAuthorizationHeader() throws URISyntaxException {
+        URI authURI = new URI("http://test.com/auth/authenticate");
+        URI refreshURI = new URI("http://test.com/auth/refreshToken");
+        JWTAuthenticator authenticator = new JWTAuthenticator(authURI,
+                refreshURI,
+                "testUser",
+                "testPassword",
+                10000,
+                10000,
+                Duration.ofMillis(100000));
+
+        authenticator.setJwtToken("fakeToken");
+        authenticator.setAuthenticationState(JWTAuthenticator.AuthenticationState.ACTIVE);
+
+        URI testURI = new URI("http://test.com/cookies");
+        HttpRequest.Builder builder = HttpRequest.newBuilder(testURI);
+        authenticator.addAuthorizationHeader(builder);
+        HttpRequest request = builder.build();
+
+        HttpHeaders headers = request.headers();
+        Optional<String> authValue = headers.firstValue("Authorization");
+
+        HttpRequest initialRequest = authenticator.generateInitialAuthenticationRequest();
+
+        Assertions.assertTrue(authValue.isPresent());
+        Assertions.assertTrue(authValue.get().startsWith("Bearer: "));
+    }
+}


### PR DESCRIPTION
This PR adds a JWT authentication option to the HTTP Client sink (see [DBZ-6348](https://issues.redhat.com/browse/DBZ-6348)).  If the JWT authentication is specified, the client will have the authenticator check for an active authentication token.  If there is no token or its expired, the authenticator will make a request for an initial or refresh token.  The authentication details will then be added to the HTTP request header.

The following options are added to the config file:

* `debezium.sink.http.authentication.type`: If missing, no authentication is used.  If present, its value specifies the authentication protocol.  The only currently supported value is `jwt`.
* `debezium.sink.http.authentication.jwt.username`: Specify the username
* `debezium.sink.http.authentication.jwt.password`: Specify the password
* `debezium.sink.http.authentication.jwt.url`: Specify the base URL.  E.g., `http://myserver:8000/`.  The paths `auth/authenticate` and `auth/refreshToken` are appended for the JWT REST calls.
* `debezium.sink.http.authentication.jwt.token_expiration`: Requested duration before token expires (in minutes)
* `debezium.sink.http.authentication.jwt.refresh_token_expiration`: Requested duration before refresh token expires (in minutes)

A separate PR to the Debezium repo will be needed to add documentation.

This PR also adds instructions to the README.md for building Debezium Server or local development.

I tested this end-to-end against a HTTP service that supports JWT authorization.  Authorization was successful.  CDC events were properly sent to the endpoint using the authorization credentials.