### PR TITLE
DBZ-6405 Set (instead of adding) Authorization Headers

### DIFF
--- a/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/Authenticator.java
@@ -8,7 +8,7 @@ package io.debezium.server.http;
 import java.net.http.HttpRequest;
 
 public interface Authenticator {
-    void addAuthorizationHeader(HttpRequest.Builder httpRequestBuilder);
+    void setAuthorizationHeader(HttpRequest.Builder httpRequestBuilder);
 
     boolean authenticate() throws InterruptedException;
 }

--- a/debezium-server-http/src/main/java/io/debezium/server/http/HttpChangeConsumer.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/HttpChangeConsumer.java
@@ -186,7 +186,7 @@ public class HttpChangeConsumer extends BaseChangeConsumer implements DebeziumEn
                 if (!authenticator.authenticate()) {
                     throw new DebeziumException("Failed to authenticate successfully.  Cannot continue.");
                 }
-                authenticator.addAuthorizationHeader(requestBuilder);
+                authenticator.setAuthorizationHeader(requestBuilder);
             }
 
             HttpRequest request = requestBuilder.build();

--- a/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
+++ b/debezium-server-http/src/main/java/io/debezium/server/http/jwt/JWTAuthenticator.java
@@ -145,7 +145,7 @@ public class JWTAuthenticator implements Authenticator {
         return builder.build();
     }
 
-    public void addAuthorizationHeader(HttpRequest.Builder httpRequestBuilder) {
+    public void setAuthorizationHeader(HttpRequest.Builder httpRequestBuilder) {
         checkAuthenticationExpired();
         if (authenticationState == AuthenticationState.NOT_AUTHENTICATED || authenticationState == AuthenticationState.FAILED_AUTHENTICATION) {
             throw new DebeziumException("Must successfully authenticate against JWT endpoint before you can add the authorization information to the HTTP header.");
@@ -154,7 +154,7 @@ public class JWTAuthenticator implements Authenticator {
             throw new DebeziumException("JWT authentication is expired. Must renew authentication before you can add the authorization information to the HTTP header.");
         }
 
-        httpRequestBuilder.header("Authorization", "Bearer: " + jwtToken);
+        httpRequestBuilder.setHeader("Authorization", "Bearer: " + jwtToken);
     }
 
     public boolean authenticate() throws InterruptedException {

--- a/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/jwt/JWTAuthenticatorTest.java
@@ -78,7 +78,7 @@ public class JWTAuthenticatorTest {
 
         URI testURI = new URI("http://test.com/cookies");
         HttpRequest.Builder builder = HttpRequest.newBuilder(testURI);
-        authenticator.addAuthorizationHeader(builder);
+        authenticator.setAuthorizationHeader(builder);
         HttpRequest request = builder.build();
 
         HttpHeaders headers = request.headers();


### PR DESCRIPTION
Set (overwrite if exists) authorization headers rather than adding them (resulting in duplicates).  Fixes [DBZ-6405](https://issues.redhat.com/browse/DBZ-6405).