### PR TITLE
DBZ-6493 Adding kubernetes-config extension in order to allow configuration from k8 config maps and secrets

### DIFF
--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-config</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.debezium</groupId>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -29,6 +29,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <quarkus.kubernetes-config.secrets.enabled>true</quarkus.kubernetes-config.secrets.enabled>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This is part of initial implementation of Debezium Operator 
https://issues.redhat.com/browse/DBZ-6493

Safely storing credentials is vital for proper k8 support.