### PR TITLE
Add more configs for rabbitmq connector

### DIFF
--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
@@ -6,7 +6,10 @@
 package io.debezium.server.rabbitmq;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Changelogs:
- exchange (optional)
- autoCreateQueue (optional)
- queuePersistent (optional)
- set routingKey to be using topic name, as @jpechane ask @olivierboudet from previous [PR review comments](https://github.com/debezium/debezium-server/pull/13#pullrequestreview-1360181651)