### PR TITLE
Add more config for rabbitmq connector

### DIFF
--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
@@ -77,6 +77,9 @@ public class RabbitMqStreamChangeConsumer extends BaseChangeConsumer implements 
     @ConfigProperty(name = PROP_PREFIX + "ackTimeout", defaultValue = "30000")
     int ackTimeout;
 
+    @ConfigProperty(name = PROP_PREFIX + "null.value", defaultValue = "default")
+    String nullValue;
+
     Connection connection;
 
     Channel channel;
@@ -141,12 +144,14 @@ public class RabbitMqStreamChangeConsumer extends BaseChangeConsumer implements 
                     LOGGER.trace("Creating queue for routing key named '{}'", routingKeyName);
                     channel.queueDeclare(routingKeyName, routingKeyDurable, false, false, null);
                 }
+
+                final Object value = (record.value() != null) ? record.value() : nullValue;
                 channel.basicPublish(exchangeName, routingKeyName,
                         new AMQP.BasicProperties.Builder()
                                 .deliveryMode(deliveryMode)
                                 .headers(convertRabbitMqHeaders(record))
                                 .build(),
-                        getBytes(record.value()));
+                        getBytes(value));
             }
             catch (IOException e) {
                 throw new DebeziumException(e);


### PR DESCRIPTION
Changelogs:
- exchange (optional)
- autoCreateRoutingKey (optional, default true)
- routingKeyDurable (optional, default true)
- deliveryMode (optional, default 2)
- set routingKey to be using topic name, as @jpechane ask @olivierboudet from previous [PR review comments](https://github.com/debezium/debezium-server/pull/13#pullrequestreview-1360181651)

[Docs PR](https://github.com/debezium/debezium/pull/4684)