### PR TITLE
DBZ-6701 enabling JNDI in order to support SRV protocol in MongoDB connector

### DIFF
--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -32,6 +32,8 @@
                 <configuration>
                     <systemProperties>
                         <quarkus.kubernetes-config.secrets.enabled>true</quarkus.kubernetes-config.secrets.enabled>
+                        <!-- Required in order to support SRV protocol in MongoDB connector (due to java drive) -->
+                        <quarkus.naming.enable-jndi>true</quarkus.naming.enable-jndi>
                     </systemProperties>
                 </configuration>
                 <executions>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6701