### PR TITLE
DBZ-6723 Allow specifying partitions for EventHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ az eventhubs namespace create --name debezium-test --resource-group eventhubstes
 
 ### Create an Event Hub
 
-Create an Event Hub (equivalent to a topic) with `one` partition. Check the documentation for options on how do this using the [Azure Portal](https://docs.microsoft.com/azure/event-hubs/event-hubs-create#create-an-event-hub), [Azure CLI](https://docs.microsoft.com/azure/event-hubs/event-hubs-quickstart-cli#create-an-event-hub) etc. , e.g. on the CLI:
+Create an Event Hub (equivalent to a topic) with 5 partitions. Check the documentation for options on how do this using the [Azure Portal](https://docs.microsoft.com/azure/event-hubs/event-hubs-create#create-an-event-hub), [Azure CLI](https://docs.microsoft.com/azure/event-hubs/event-hubs-quickstart-cli#create-an-event-hub) etc. , e.g. on the CLI:
 
 ```shell
-az eventhubs eventhub create --name debezium-test-hub --resource-group eventhubstest --namespace-name debezium-test
+`az eventhubs eventhub create` --name debezium-test-hub --resource-group eventhubstest --namespace-name debezium-test --partition-count 5
 ```
 
 ### Build the module

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -38,10 +38,11 @@
             <artifactId>debezium-testing-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
-<dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope></dependency>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.azure.messaging.eventhubs.EventData;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.models.CreateBatchOptions;
+
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+
+public class BatchManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BatchManager.class);
+    private final EventHubProducerClient producer;
+    private final boolean forceSinglePartitionMode;
+    private final String partitionID;
+    private final String partitionKey;
+    private final Integer maxBatchSize;
+
+    // Prepare CreateBatchOptions for N partitions
+    private final HashMap<Integer, CreateBatchOptions> batchOptions = new HashMap<>();
+    private final HashMap<Integer, EventDataBatchProxy> batches = new HashMap<>();
+    private final HashMap<Integer, ArrayList<Integer>> processedRecordIndices = new HashMap<>();
+    private List<ChangeEvent<Object, Object>> records;
+    private DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer;
+
+    public BatchManager(EventHubProducerClient producer, boolean forceSinglePartitionMode,
+                        String partitionID, String partitionKey, Integer maxBatchSize) {
+        this.producer = producer;
+        this.forceSinglePartitionMode = forceSinglePartitionMode;
+        this.partitionID = partitionID;
+        this.partitionKey = partitionKey;
+        this.maxBatchSize = maxBatchSize;
+    }
+
+    public void initializeBatch(List<ChangeEvent<Object, Object>> records,
+                                DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer) {
+        this.records = records;
+        this.committer = committer;
+
+        if (forceSinglePartitionMode) {
+            CreateBatchOptions op = new CreateBatchOptions();
+
+            if (!partitionID.isEmpty()) {
+                op.setPartitionId(partitionID);
+
+                batchOptions.put(Integer.parseInt(partitionID), op);
+                batches.put(Integer.parseInt(partitionID), new EventDataBatchProxy(producer, op));
+                processedRecordIndices.put(Integer.parseInt(partitionID), new ArrayList<>());
+            }
+
+            if (!partitionKey.isEmpty()) {
+                op.setPartitionKey(partitionKey);
+
+                batchOptions.put(0, op);
+                batches.put(0, new EventDataBatchProxy(producer, op));
+                processedRecordIndices.put(0, new ArrayList<>());
+            }
+
+            if (maxBatchSize != 0) {
+                op.setMaximumSizeInBytes(maxBatchSize);
+            }
+
+            return;
+        }
+
+        producer.getPartitionIds().stream().forEach(partitionId -> {
+            CreateBatchOptions op = new CreateBatchOptions().setPartitionId(partitionId);
+            if (maxBatchSize != 0) {
+                op.setMaximumSizeInBytes(maxBatchSize);
+            }
+            batchOptions.put(Integer.parseInt(partitionId), op);
+        });
+        // Prepare batches
+        batchOptions.forEach((partitionId, batchOption) -> {
+            EventDataBatchProxy batch = new EventDataBatchProxy(producer, batchOption);
+            batches.put(partitionId, batch);
+            processedRecordIndices.put(partitionId, new ArrayList<>());
+        });
+
+    }
+
+    public void closeAndEmitBatches() {
+        // All records have been processed, emit the final (non-full) batches.
+        batches.forEach((partitionId, batch) -> {
+            if (batch.getCount() > 0) {
+                LOGGER.trace("Dispatching {} events.", batch.getCount());
+                emitBatchToEventHub(records, committer, processedRecordIndices.get(partitionId), batch);
+            }
+        });
+    }
+
+    public void sendEventToPartitionId(EventData eventData, Integer recordIndex, Integer partitionId) {
+        EventDataBatchProxy batch = batches.get(partitionId);
+
+        if (!batch.tryAdd(eventData)) {
+            if (batch.getCount() == 0) {
+                // If we fail to add at least the very first event to the batch that is because
+                // the event's size exceeds the maxBatchSize in which case we cannot safely
+                // recover and dispatch the event, only option is to throw an exception.
+                throw new DebeziumException("Event data is too large to fit into batch");
+            }
+            // reached the maximum allowed size for the batch
+            LOGGER.trace("Maximum batch reached, dispatching {} events.", batch.getCount());
+
+            // Max size reached, dispatch the batch to EventHub
+            emitBatchToEventHub(records, committer, processedRecordIndices.get(partitionId), batch);
+            // Renew the batch proxy so we can continue.
+            batch = new EventDataBatchProxy(producer, batchOptions.get(partitionId));
+            batches.put(partitionId, batch);
+            processedRecordIndices.put(partitionId, new ArrayList<>());
+        }
+
+        // Record the index of the record that was added to the batch.
+        processedRecordIndices.get(partitionId).add(recordIndex);
+    }
+
+    private void emitBatchToEventHub(List<ChangeEvent<Object, Object>> records, DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer,
+                                     ArrayList<Integer> processedIndices, EventDataBatchProxy batch) {
+        final int batchEventSize = batch.getCount();
+        if (batchEventSize > 0) {
+            try {
+                LOGGER.trace("Sending batch of {} events to Event Hubs", batchEventSize);
+                batch.emit();
+                LOGGER.trace("Sent record batch to Event Hubs");
+            }
+            catch (Exception e) {
+                throw new DebeziumException(e);
+            }
+
+            // this loop commits each record submitted in the event hubs batch
+            List<String> processedIndexesStrings = processedIndices.stream().map(Object::toString).collect(Collectors.toList());
+            LOGGER.trace("Marking records as processed: {}", String.join("; ", processedIndexesStrings));
+            processedIndices.forEach(
+                    index -> {
+                        ChangeEvent<Object, Object> record = records.get(index);
+                        try {
+                            committer.markProcessed(record);
+                            LOGGER.trace("Record marked processed");
+                        }
+                        catch (Exception e) {
+                            throw new DebeziumException(e);
+                        }
+                    });
+        }
+    }
+}

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
@@ -113,7 +113,7 @@ public class BatchManager {
                 throw new DebeziumException("Event data is too large to fit into batch");
             }
             // reached the maximum allowed size for the batch
-            LOGGER.trace("Maximum batch reached, dispatching {} events.", batch.getCount());
+            LOGGER.debug("Maximum batch size reached, dispatching {} events.", batch.getCount());
 
             // Max size reached, dispatch the batch to EventHub
             emitBatchToEventHub(records, committer, processedRecordIndices.get(partitionId), batch);

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventDataBatchProxy.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventDataBatchProxy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import com.azure.messaging.eventhubs.EventData;
+import com.azure.messaging.eventhubs.EventDataBatch;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.models.CreateBatchOptions;
+
+/**
+ * Proxy class/wrapper for EventDataBatch. Will create an inner EventDataBatch when data is being emitted to a specific
+ * partition.
+ */
+public class EventDataBatchProxy {
+    private EventDataBatch batch;
+    private final EventHubProducerClient producer;
+    private final CreateBatchOptions batchOptions;
+
+    public EventDataBatchProxy(EventHubProducerClient producer, CreateBatchOptions batchOptions) {
+        this.producer = producer;
+        this.batchOptions = batchOptions;
+    }
+
+    public boolean tryAdd(final EventData eventData) {
+        if (this.batch == null) {
+            this.batch = producer.createBatch(this.batchOptions);
+        }
+
+        return batch.tryAdd(eventData);
+    }
+
+    public int getCount() {
+        if (this.batch == null) {
+            return 0;
+        }
+
+        return batch.getCount();
+    }
+
+    public void emit() {
+        if (this.batch == null) {
+            return;
+        }
+
+        producer.send(this.batch);
+    }
+}

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -165,10 +165,14 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
                 }
                 else {
                     targetPartitionId = record.partition();
+
+                    if (targetPartitionId == null) {
+                        targetPartitionId = BatchManager.BATCH_INDEX_FOR_NO_PARTITION_ID;
+                    }
                 }
 
                 // Check that the target partition exists.
-                if (targetPartitionId < 0 || targetPartitionId > partitionCount - 1) {
+                if (targetPartitionId < BatchManager.BATCH_INDEX_FOR_NO_PARTITION_ID || targetPartitionId > partitionCount - 1) {
                     throw new IndexOutOfBoundsException(
                             String.format("Target partition id %d does not exist in target EventHub %s", targetPartitionId, eventHubName));
                 }

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -102,6 +102,11 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
         // Retrieve available partition count for the EventHub
         partitionCount = (int) producer.getPartitionIds().stream().count();
         LOGGER.trace("Event Hub '{}' has {} partitions available", producer.getEventHubName(), partitionCount);
+
+        if (!configuredPartitionId.isEmpty() && Integer.parseInt(configuredPartitionId) > partitionCount - 1) {
+            throw new IndexOutOfBoundsException(
+                    String.format("Target partition id %s does not exist in target EventHub %s", configuredPartitionId, eventHubName));
+        }
     }
 
     @PreDestroy
@@ -160,6 +165,12 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
                 }
                 else {
                     targetPartitionId = record.partition();
+                }
+
+                // Check that the target partition exists.
+                if (targetPartitionId < 0 || targetPartitionId > partitionCount - 1) {
+                    throw new IndexOutOfBoundsException(
+                            String.format("Target partition id %d does not exist in target EventHub %s", targetPartitionId, eventHubName));
                 }
 
                 try {

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -169,7 +169,6 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
                 }
                 else {
                     partitionId = record.partition();
-                    LOGGER.warn("Routing event to partition {}", record.partition());
                 }
 
                 try {

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -196,6 +196,11 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
         }
 
         batchManager.closeAndEmitBatches();
+
+        LOGGER.trace("Marking {} records as processed.", records.size());
+        for (ChangeEvent<Object, Object> record : records) {
+            committer.markProcessed(record);
+        }
         committer.markBatchFinished();
         LOGGER.trace("Batch marked finished");
     }

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
@@ -25,6 +25,7 @@ public class EventHubsTestConfigSource extends TestConfigSource {
         eventHubsTest.put("debezium.sink.type", "eventhubs");
         eventHubsTest.put("debezium.sink.eventhubs.connectionstring", getEventHubsConnectionString());
         eventHubsTest.put("debezium.sink.eventhubs.hubname", getEventHubsName());
+        eventHubsTest.put("debezium.sink.eventhubs.partitionid", "0");
 
         // postgresql source config
 

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
@@ -25,7 +25,6 @@ public class EventHubsTestConfigSource extends TestConfigSource {
         eventHubsTest.put("debezium.sink.type", "eventhubs");
         eventHubsTest.put("debezium.sink.eventhubs.connectionstring", getEventHubsConnectionString());
         eventHubsTest.put("debezium.sink.eventhubs.hubname", getEventHubsName());
-        eventHubsTest.put("debezium.sink.eventhubs.partitionid", "0");
 
         // postgresql source config
 

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyIT.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.azure.core.util.IterableStream;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
+import com.azure.messaging.eventhubs.EventHubConsumerClient;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.models.EventPosition;
+import com.azure.messaging.eventhubs.models.PartitionEvent;
+
+import io.debezium.server.DebeziumServer;
+import io.debezium.server.events.ConnectorCompletedEvent;
+import io.debezium.server.events.ConnectorStartedEvent;
+import io.debezium.testing.testcontainers.PostgresTestResourceLifecycleManager;
+import io.debezium.util.Testing;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Integration test that verifies basic reading from PostgreSQL database and
+ * writing to Azure Event Hubs using a fixed partition key.
+ *
+ * @author Sebastiaan Knijnenburg
+ */
+@QuarkusTest
+@TestProfile(EventHubsWithPartitionKeyProfile.class)
+@QuarkusTestResource(PostgresTestResourceLifecycleManager.class)
+public class EventHubsWithPartitionKeyIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventHubsWithPartitionKeyIT.class);
+
+    private static final int MESSAGE_COUNT = 4;
+    private static final String CONSUMER_GROUP = "$Default";
+
+    protected static EventHubProducerClient producer = null;
+    protected static EventHubConsumerClient consumer = null;
+
+    {
+        Testing.Files.delete(EventHubsTestConfigSource.OFFSET_STORE_PATH);
+        Testing.Files.createTestingFile(EventHubsTestConfigSource.OFFSET_STORE_PATH);
+    }
+
+    @AfterAll
+    static void stop() {
+        if (producer != null) {
+            producer.close();
+        }
+        if (consumer != null) {
+            consumer.close();
+        }
+    }
+
+    @Inject
+    DebeziumServer server;
+
+    void setupDependencies(@Observes ConnectorStartedEvent event) {
+        String finalConnectionString = String.format("%s;EntityPath=%s",
+                EventHubsTestConfigSource.getEventHubsConnectionString(), EventHubsTestConfigSource.getEventHubsName());
+
+        producer = new EventHubClientBuilder().connectionString(finalConnectionString).buildProducerClient();
+    }
+
+    void connectorCompleted(@Observes ConnectorCompletedEvent event) throws Exception {
+        if (!event.isSuccess()) {
+            throw (Exception) event.getError().get();
+        }
+    }
+
+    @Test
+    public void testEventHubsWithPartitionKey() throws Exception {
+        Testing.Print.enable();
+
+        String finalConnectionString = String.format("%s;EntityPath=%s",
+                EventHubsTestConfigSource.getEventHubsConnectionString(), EventHubsTestConfigSource.getEventHubsName());
+
+        consumer = new EventHubClientBuilder().connectionString(finalConnectionString).consumerGroup(CONSUMER_GROUP)
+                .buildConsumerClient();
+
+        final List<PartitionEvent> expected = new ArrayList<>();
+
+        Awaitility.await().atMost(Duration.ofSeconds(EventHubsTestConfigSource.waitForSeconds())).until(() -> {
+            IterableStream<PartitionEvent> events = consumer.receiveFromPartition("3", MESSAGE_COUNT,
+                    EventPosition.latest());
+
+            events.forEach(event -> expected.add(event));
+            return expected.size() >= MESSAGE_COUNT;
+        });
+
+        // check whether the event data contains expected id i.e. 1001, 1002, 1003 and
+        // 1004
+        String eventBody = null;
+        String expectedID = null;
+        final String idPart = "\"id\":100";
+
+        // since all messages go to same partition, ordering will be maintained
+        // (assuming no errors)
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            eventBody = expected.get(i).getData().getBodyAsString();
+            expectedID = idPart + String.valueOf(i + 1);
+            assertTrue(eventBody.contains(expectedID), expectedID + " not found in payload");
+        }
+    }
+}

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyProfile.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyProfile.java
@@ -16,7 +16,6 @@ public class EventHubsWithPartitionKeyProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         Map<String, String> config = new HashMap<String, String>();
 
-        config.put("debezium.sink.eventhubs.partitionid", "");
         config.put("debezium.sink.eventhubs.partitionkey", "my-fixed-partition-key");
 
         return config;

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyProfile.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionKeyProfile.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class EventHubsWithPartitionKeyProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<String, String>();
+
+        config.put("debezium.sink.eventhubs.partitionid", "");
+        config.put("debezium.sink.eventhubs.partitionkey", "my-fixed-partition-key");
+
+        return config;
+    }
+}

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterIT.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.azure.core.util.IterableStream;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
+import com.azure.messaging.eventhubs.EventHubConsumerClient;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.models.EventPosition;
+import com.azure.messaging.eventhubs.models.PartitionEvent;
+
+import io.debezium.server.DebeziumServer;
+import io.debezium.server.events.ConnectorCompletedEvent;
+import io.debezium.server.events.ConnectorStartedEvent;
+import io.debezium.testing.testcontainers.PostgresTestResourceLifecycleManager;
+import io.debezium.util.Testing;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Integration test that verifies basic reading from PostgreSQL database and
+ * writing to Azure Event Hubs.
+ *
+ * @author Abhishek Gupta
+ */
+@QuarkusTest
+@TestProfile(EventHubsWithPartitionRouterProfile.class)
+@QuarkusTestResource(PostgresTestResourceLifecycleManager.class)
+public class EventHubsWithPartitionRouterIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventHubsWithPartitionRouterIT.class);
+
+    private static final int MESSAGE_COUNT = 4;
+    private static final String CONSUMER_GROUP = "$Default";
+
+    protected static EventHubProducerClient producer = null;
+    protected static EventHubConsumerClient consumer = null;
+
+    {
+        Testing.Files.delete(EventHubsTestConfigSource.OFFSET_STORE_PATH);
+        Testing.Files.createTestingFile(EventHubsTestConfigSource.OFFSET_STORE_PATH);
+    }
+
+    @AfterAll
+    static void stop() {
+        if (producer != null) {
+            producer.close();
+        }
+        if (consumer != null) {
+            consumer.close();
+        }
+    }
+
+    @Inject
+    DebeziumServer server;
+
+    void setupDependencies(@Observes ConnectorStartedEvent event) {
+        String finalConnectionString = String.format("%s;EntityPath=%s",
+                EventHubsTestConfigSource.getEventHubsConnectionString(), EventHubsTestConfigSource.getEventHubsName());
+
+        producer = new EventHubClientBuilder().connectionString(finalConnectionString).buildProducerClient();
+    }
+
+    void connectorCompleted(@Observes ConnectorCompletedEvent event) throws Exception {
+        if (!event.isSuccess()) {
+            throw (Exception) event.getError().get();
+        }
+    }
+
+    @Test
+    public void testEventHubsWithCustomPartitionConfiguration() throws Exception {
+        Testing.Print.enable();
+
+        String finalConnectionString = String.format("%s;EntityPath=%s",
+                EventHubsTestConfigSource.getEventHubsConnectionString(), EventHubsTestConfigSource.getEventHubsName());
+
+        consumer = new EventHubClientBuilder().connectionString(finalConnectionString).consumerGroup(CONSUMER_GROUP)
+                .buildConsumerClient();
+
+        final List<PartitionEvent> expected = new ArrayList<>();
+
+        Awaitility.await().atMost(Duration.ofSeconds(EventHubsTestConfigSource.waitForSeconds())).until(() -> {
+            IterableStream<PartitionEvent> events = consumer.receiveFromPartition("1", MESSAGE_COUNT,
+                    EventPosition.latest());
+
+            events.forEach(event -> expected.add(event));
+            return expected.size() >= MESSAGE_COUNT;
+        });
+
+        // check whether the event data contains expected id i.e. 1001, 1002, 1003 and
+        // 1004
+        String eventBody = null;
+        String expectedID = null;
+        final String idPart = "\"id\":100";
+
+        // since all messages go to same partition, ordering will be maintained
+        // (assuming no errors)
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            eventBody = expected.get(i).getData().getBodyAsString();
+            expectedID = idPart + String.valueOf(i + 1);
+            assertTrue(eventBody.contains(expectedID), expectedID + " not found in payload");
+        }
+    }
+}

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterProfile.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterProfile.java
@@ -16,9 +16,6 @@ public class EventHubsWithPartitionRouterProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         Map<String, String> config = new HashMap<String, String>();
 
-        config.put("debezium.sink.eventhubs.partitionid", "");
-        config.put("debezium.sink.eventhubs.partitionkey", "");
-
         config.put("debezium.transforms", "PartitionRouter");
         config.put("debezium.transforms.PartitionRouter.type", "io.debezium.transforms.partitions.PartitionRouting");
         config.put("debezium.transforms.PartitionRouter.partition.payload.fields", "source.db");

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterProfile.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithPartitionRouterProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class EventHubsWithPartitionRouterProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<String, String>();
+
+        config.put("debezium.sink.eventhubs.partitionid", "");
+        config.put("debezium.sink.eventhubs.partitionkey", "");
+
+        config.put("debezium.transforms", "PartitionRouter");
+        config.put("debezium.transforms.PartitionRouter.type", "io.debezium.transforms.partitions.PartitionRouting");
+        config.put("debezium.transforms.PartitionRouter.partition.payload.fields", "source.db");
+        config.put("debezium.transforms.PartitionRouter.partition.topic.num", "5");
+
+        return config;
+    }
+}

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithStaticPartitionIdIT.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithStaticPartitionIdIT.java
@@ -17,8 +17,6 @@ import jakarta.inject.Inject;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.azure.core.util.IterableStream;
 import com.azure.messaging.eventhubs.EventHubClientBuilder;
@@ -34,6 +32,7 @@ import io.debezium.testing.testcontainers.PostgresTestResourceLifecycleManager;
 import io.debezium.util.Testing;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 
 /**
  * Integration test that verifies basic reading from PostgreSQL database and
@@ -42,11 +41,9 @@ import io.quarkus.test.junit.QuarkusTest;
  * @author Abhishek Gupta
  */
 @QuarkusTest
+@TestProfile(EventHubsWithStaticPartitionIdProfile.class)
 @QuarkusTestResource(PostgresTestResourceLifecycleManager.class)
-public class EventHubsIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EventHubsIT.class);
-
+public class EventHubsWithStaticPartitionIdIT {
     private static final int MESSAGE_COUNT = 4;
     private static final String CONSUMER_GROUP = "$Default";
 
@@ -85,7 +82,7 @@ public class EventHubsIT {
     }
 
     @Test
-    public void testEventHubs() throws Exception {
+    public void testEventHubsWithFixedPartitionId() throws Exception {
         Testing.Print.enable();
 
         String finalConnectionString = String.format("%s;EntityPath=%s",

--- a/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithStaticPartitionIdProfile.java
+++ b/debezium-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsWithStaticPartitionIdProfile.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.eventhubs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class EventHubsWithStaticPartitionIdProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<String, String>();
+
+        config.put("debezium.sink.eventhubs.partitionid", "0");
+
+        return config;
+    }
+}


### PR DESCRIPTION
Link: https://issues.redhat.com/browse/DBZ-6723

## Background

With the existing Azure EventHubs sink implementation it is not possible to leverage multiple partitions on the EventHubs side. One can either hardcode the partitionID where _all_ messages will be sent to, or a fixed partitionKey, which will make EventHubs pick a single partition derived from that key. Being only able to leverage a single partition makes it hard to parallelise any downstream processing. This is something we ran into when processing ~900GB of messages from a single large database server.

The EventHubs SDK only allows specifying the partition (either via an ID or a key) on a batch level, as the entire batch of messages is being emitted as a single message under the hood. This means that in order to send messages to N partitions, we need to manage N potential batches and we need to route  events to the correct batch to ultimately make the message arrive in the correct EventHubs partition.

## Changes

This PR adds supports to sends events to multiple EventHubs partitions based on input from the PartitionRouter SMT. In order to be able to read the partition number from the ChangeEvent, its interface had to be changed, for this there is an [open PR](https://github.com/debezium/debezium/pull/5041) in the `debezium` repository on which this PR depends.

A new BatchManager class now create batches for every partition, and assigns EventData object to a specific batch based on the partition derived from the ChangeEvent. When a batch hits its maximum size (1024KB), the batch is emitted to EventHubs and a new batch is created.

When all incoming records have been processed all open/remaining batches are emitted if they contain any EventData.

As creating an EventDataBatch initiates a connection over AMQP, that adds quite a bit of overhead. By putting the batch creation behind a proxy class, we only create the real EventDataBatch when it is necessary, saving a bit of overhead.

## Other notes

- The partitionID assignment is depending on the number of partitions available in the EventHub instance. I've updated the integration tests to use an EventHub with 5 partitions. In order to reproduce the same routing anyone testing should have an EventHub with 5 partitions as well, the documentation was updated to reflect this.
- This PR is a follow-up/replacement of https://github.com/debezium/debezium-server/pull/33.