### PR TITLE
DBZ-7216 Adjusting to changed CE type value

### DIFF
--- a/debezium-server-http/src/test/java/io/debezium/server/http/HttpIT.java
+++ b/debezium-server-http/src/test/java/io/debezium/server/http/HttpIT.java
@@ -150,12 +150,12 @@ public class HttpIT {
                 };
                 hm = om.readValue(request.getBody(), tref);
 
-                Assertions.assertEquals("/debezium/postgresql/testc", (String) hm.get("source"));
-                Assertions.assertEquals("io.debezium.postgresql.datachangeevent", (String) hm.get("type"));
-                Assertions.assertEquals("1.0", (String) hm.get("specversion"));
-                Assertions.assertEquals("postgres", (String) hm.get("iodebeziumdb"));
-                Assertions.assertEquals("inventory", (String) hm.get("iodebeziumschema"));
-                Assertions.assertEquals("customers", (String) hm.get("iodebeziumtable"));
+                Assertions.assertEquals("/debezium/postgresql/testc", hm.get("source"));
+                Assertions.assertEquals("io.debezium.connector.postgresql.DataChangeEvent", hm.get("type"));
+                Assertions.assertEquals("1.0", hm.get("specversion"));
+                Assertions.assertEquals("postgres", hm.get("iodebeziumdb"));
+                Assertions.assertEquals("inventory", hm.get("iodebeziumschema"));
+                Assertions.assertEquals("customers", hm.get("iodebeziumtable"));
                 String eventID = (String) hm.get("id");
                 Assertions.assertTrue(eventID.length() > 0);
 


### PR DESCRIPTION
@jpechane, @Naros, looks like a missing leftover from DBZ-7216 to me. That being said, I'm somewhat doubtful about this change in the first place:

* It seems unexpected in a non-minor release?
* If it actually should be changed, the [documentation](https://debezium.io/documentation/reference/stable/integrations/cloudevents.html) needs updating as well
* Is there a CI build missing which would have flagged this early on?