### PR TITLE
DBZ-7576 Use fixed port for Redis server

### DIFF
--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisTestResourceLifecycleManager.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisTestResourceLifecycleManager.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import io.debezium.server.TestConfigSource;
@@ -23,11 +23,12 @@ public class RedisTestResourceLifecycleManager implements QuarkusTestResourceLif
 
     static final String READY_MESSAGE = "Ready to accept connections";
     public static final int REDIS_PORT = 6379;
+    public static final int HOST_PORT = 16379;
     public static final String REDIS_IMAGE = "redis";
 
     private static final AtomicBoolean running = new AtomicBoolean(false);
-    private static final GenericContainer<?> container = new GenericContainer<>(REDIS_IMAGE)
-            .withExposedPorts(REDIS_PORT);
+    private static final FixedHostPortGenericContainer<?> container = new FixedHostPortGenericContainer<>(REDIS_IMAGE)
+            .withFixedExposedPort(HOST_PORT, REDIS_PORT);
 
     private static synchronized void start(boolean ignored) {
         if (!running.get()) {


### PR DESCRIPTION
When the Redis container uses random port, even single test fails with `Unexpected end of stream` exception on my machine. I observed that it starts working when Redis uses fixed port. Unfortunatelly I have no clue what is the root cause.

Try to switch to fixed port and see if it helps also on the CI and the testsuite will be more stable. Or vice versa - if it makes things worse and there will be port conflicts.

https://issues.redhat.com/browse/DBZ-7576