### PR TITLE
DBZ-7841 Align dependencies with Quarkus 3.8.3

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -17,7 +17,7 @@
         <version.pubsub>26.17.0</version.pubsub>
         <version.pulsar>2.10.1</version.pulsar>
         <version.eventhubs>5.12.1</version.eventhubs>
-        <version.pravega>0.9.1</version.pravega>
+        <version.pravega>0.13.0</version.pravega>
         <version.nats>2.16.3</version.nats>
         <version.stan>2.2.3</version.stan>
         <version.commons.logging>1.2</version.commons.logging>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -10,7 +10,7 @@
   <name>Debezium Server Pravega Sink Adapter</name>
   <properties>
     <!-- IMPORTANT: This must be aligned with the netty shipped with Quarkus, specified in debezium-build-parent -->
-    <netty.version>4.1.100.Final</netty.version>
+    <netty.version>4.1.107.Final</netty.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/debezium-server-pravega/src/test/java/io/debezium/server/pravega/PravegaTestResource.java
+++ b/debezium-server-pravega/src/test/java/io/debezium/server/pravega/PravegaTestResource.java
@@ -28,7 +28,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
  */
 public class PravegaTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String PRAVEGA_VERSION = "0.9.0";
+    private static final String PRAVEGA_VERSION = "0.13.0";
     public static final int CONTROLLER_PORT = 9090;
     public static final int SEGMENT_STORE_PORT = 12345;
     public static final String PRAVEGA_IMAGE = "pravega/pravega:" + PRAVEGA_VERSION;
@@ -38,7 +38,7 @@ public class PravegaTestResource implements QuarkusTestResourceLifecycleManager 
             .withFixedExposedPort(CONTROLLER_PORT, CONTROLLER_PORT)
             .withFixedExposedPort(SEGMENT_STORE_PORT, SEGMENT_STORE_PORT)
             .withStartupTimeout(Duration.ofSeconds(90))
-            .waitingFor(Wait.forLogMessage(".*Starting gRPC server listening on port: 9090.*", 1))
+            .waitingFor(Wait.forLogMessage(".*Pravega Sandbox is running locally now. You could access it at 127.0.0.1:9090.*", 1))
             .withCommand("standalone");
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7841

### Dependency adjustments

* Bumped pravega-client to 0.13.0
* Aligned netty to 4.1.107.Final