### PR TITLE
DBZ-8108 implemente option AddressResolver for rabbitmq native stream

### DIFF
--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.ConnectionFactoryConfigurator;
+import com.rabbitmq.stream.Address;
 import com.rabbitmq.stream.Environment;
 import com.rabbitmq.stream.Producer;
 import com.rabbitmq.stream.StreamException;
@@ -80,9 +81,12 @@ public class RabbitMqStreamNativeChangeConsumer extends BaseChangeConsumer imple
         LOGGER.info("Using connection to {}:{}", factory.getHost(), factory.getPort());
 
         try {
+            Address entryPoint = new Address(factory.getHost(), factory.getPort());
             environment = Environment.builder()
-                    .host(factory.getHost())
-                    .port(factory.getPort()).build();
+                    .host(entryPoint.host())
+                    .port(entryPoint.port())
+                    .addressResolver(address -> entryPoint)
+                    .build();
 
             if (stream.isEmpty()) {
                 throw new DebeziumException("Mandatory configration option '" + PROP_STREAM + "' is not provided");


### PR DESCRIPTION
When use rabbitmq native stream as sink for dbz, it will produce error as like: "Error while creating stream connection to fdb49ba7df14:5552. fdb49ba7df14: Name or service not known. This may be due to the usage of a load balancer that makes topology discovery fail. Use a custom AddressResolver or the --load-balancer flag if using StreamPerfTest".

From the docs https://rabbitmq.github.io/rabbitmq-stream-java-client/stable/htmlsingle/#understanding-connection-logic
We need to use options "AddressResolver" to let it connect successful