### PR TITLE
Rabbitmq native streams support separate streams per table and fix st…

### DIFF
--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamIT.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamIT.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import com.rabbitmq.stream.Address;
 import jakarta.enterprise.event.Observes;
 
 import org.awaitility.Awaitility;
@@ -76,9 +77,15 @@ public class RabbitMqStreamIT {
         factory.setHost(RabbitMqStreamTestResourceLifecycleManager.container.getHost());
         factory.setPort(RabbitMqStreamTestResourceLifecycleManager.getPort());
 
+        Address entryPoint = new Address(factory.getHost(), factory.getPort());
         environment = Environment.builder()
-                .host(factory.getHost())
-                .port(factory.getPort()).build();
+                .host(entryPoint.host())
+                .port(entryPoint.port())
+                .addressResolver(address -> entryPoint)
+                .username(factory.getUsername())
+                .password(factory.getPassword())
+                .virtualHost(factory.getVirtualHost())
+                .build();
 
         environment.streamCreator().stream(RabbitMqTestConfigSource.TOPIC_NAME).create();
 


### PR DESCRIPTION
This is a new feature for rabbitmq native stream.

Currently, all table changes are send to one stream.I think it is not very well for many situation.

So I change it, and add some options for it and it doesn't affect current user.

And I fix that without specifying username and password and virtual host when connect,it will use guest/guest rather than setting of properties.