### PR TITLE
DBZ-7575 Resolve all futures before marking a batch as completed in Kafka sink

### DIFF
--- a/debezium-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
+++ b/debezium-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
@@ -118,7 +118,12 @@ public class KafkaChangeConsumer extends BaseChangeConsumer implements DebeziumE
 
         for (Future<RecordMetadata> future : futures) {
             try {
-                future.get(waitMessageDeliveryTimeout, TimeUnit.MILLISECONDS);
+                if (waitMessageDeliveryTimeout == 0) {
+                    future.get();
+                }
+                else {
+                    future.get(waitMessageDeliveryTimeout, TimeUnit.MILLISECONDS);
+                }
             }
             catch (TimeoutException | ExecutionException e) {
                 throw new DebeziumException("Error while waiting for Kafka send operations to complete", e);


### PR DESCRIPTION
Resolve futures before marking a batch as completed for Kafka sink

This will make sure that records are being send or we crash the sink instead of sink being blocked forever.