### PR TITLE
[DBZ-7909] RabbitMQ Native Stream: Making sure RequestedFrameMax get sent to StreamClient

### DIFF
--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
@@ -111,6 +111,7 @@ public class RabbitMqStreamNativeChangeConsumer extends BaseChangeConsumer imple
                     .username(factory.getUsername())
                     .password(factory.getPassword())
                     .virtualHost(factory.getVirtualHost())
+                    .requestedMaxFrameSize(factory.getRequestedFrameMax())
                     .build();
         }
         catch (StreamException | IllegalArgumentException e) {

--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
@@ -48,6 +48,14 @@ public class RabbitMqStreamNativeChangeConsumer extends BaseChangeConsumer imple
 
     private static final String PROP_PREFIX = "debezium.sink.rabbitmqstream.";
 
+    @Deprecated
+    @ConfigProperty(name = PROP_PREFIX + "connection.host")
+    String legacyHost;
+
+    @Deprecated
+    @ConfigProperty(name = PROP_PREFIX + "connection.port")
+    int legacyPort;
+
     @ConfigProperty(name = PROP_PREFIX + "host", defaultValue = "localhost")
     String host;
 
@@ -137,10 +145,17 @@ public class RabbitMqStreamNativeChangeConsumer extends BaseChangeConsumer imple
 
     @PostConstruct
     void connect() {
-        LOGGER.info("Using connection to {}:{}", host, port);
+        if(legacyHost != null || legacyPort > 0) {
+            LOGGER.warn("The parameters connection.host and connection.port are deprecated, please use rabbitmqstream.host and rabbitmqstream.port moving forward.");
+        }
+
+        String connectionHost = legacyHost != null ? legacyHost : host;
+        int connectionPort = legacyPort > 0 ? legacyPort : port;
+
+        LOGGER.info("Using connection to {}:{}", connectionHost, connectionPort);
 
         try {
-            Address entryPoint = new Address(host, port);
+            Address entryPoint = new Address(connectionHost, connectionPort);
             environment = Environment.builder()
                     .host(entryPoint.host())
                     .port(entryPoint.port())

--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamTestResourceLifecycleManager.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamTestResourceLifecycleManager.java
@@ -42,8 +42,8 @@ public class RabbitMqStreamTestResourceLifecycleManager implements QuarkusTestRe
             throw new RuntimeException(e);
         }
         Map<String, String> params = new ConcurrentHashMap<>();
-        params.put("debezium.sink.rabbitmqstream.connection.host", container.getHost());
-        params.put("debezium.sink.rabbitmqstream.connection.port", String.valueOf(getPort()));
+        params.put("debezium.sink.rabbitmqstream.host", container.getHost());
+        params.put("debezium.sink.rabbitmqstream.port", String.valueOf(getPort()));
         return params;
     }
 


### PR DESCRIPTION
This fixes an issue I was having where I was setting the frame_max variable on the connection configuration but it was not propagating to the StreamClient. This patch fixes this issue.

https://issues.redhat.com/browse/DBZ-7909