### PR TITLE
DBZ-8236 Adjusted committer.markProcessed(record) to only execute after confirmed receipt of published messages by Pubsub

### DIFF
--- a/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
+++ b/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
@@ -265,8 +265,6 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
             PubsubMessage message = buildPubSubMessage(record);
 
             deliveries.add(publisher.publish(message));
-
-            committer.markProcessed(record);
         }
         List<String> messageIds;
         try {
@@ -276,6 +274,12 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
             throw new DebeziumException(e);
         }
         LOGGER.trace("Sent messages with ids: {}", messageIds);
+
+        // Once publishing is confirmed, mark all records as processed
+        for (ChangeEvent<Object, Object> record : records) {
+            committer.markProcessed(record);
+        }
+
         committer.markBatchFinished();
     }
 

--- a/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubLiteChangeConsumer.java
+++ b/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubLiteChangeConsumer.java
@@ -132,7 +132,6 @@ public class PubSubLiteChangeConsumer extends BaseChangeConsumer implements Debe
             PubsubMessage message = buildPubSubMessage(record);
 
             deliveries.add(publisher.publish(message));
-            committer.markProcessed(record);
         }
         List<String> messageIds;
         try {
@@ -142,6 +141,12 @@ public class PubSubLiteChangeConsumer extends BaseChangeConsumer implements Debe
             throw new DebeziumException(e);
         }
         LOGGER.trace("Sent messages with ids: {}", messageIds);
+
+        // Once publishing is confirmed, mark all records as processed
+        for (ChangeEvent<Object, Object> record : records) {
+            committer.markProcessed(record);
+        }
+
         committer.markBatchFinished();
     }
 


### PR DESCRIPTION
Hi there,

As discussed on jira ticket and here: https://debezium.zulipchat.com/#narrow/stream/350571-community-dbz-server/topic/Understanding.20record.2Ecommitter.20behaviour.20in.20Debezium.20server

I made the change in PubSubChangeConsumer as well as in PubSubLite as the same issue would occur there.  In this case, I wait until messageIds = ApiFutures.allAsList(deliveries).get(waitMessageDeliveryTimeout, TimeUnit.MILLISECONDS); completes before marking messages as processed.

From my testing, this resolves the issue.  Would it be possible also for this change to be added to the 2.7 branch?  Currently in Prod we would like to continue on the 2.7 and then just upgrade to 2.7.x.