### PR TITLE
DBZ-8299 - Upgrade Google BOM for PubSub

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <version.kinesis>2.13.13</version.kinesis>
         <version.sqs>2.13.13</version.sqs>
-        <version.pubsub>26.17.0</version.pubsub>
+        <version.pubsub>26.48.0</version.pubsub>
         <version.pulsar>2.10.1</version.pulsar>
         <version.eventhubs>5.12.1</version.eventhubs>
         <version.pravega>0.13.0</version.pravega>


### PR DESCRIPTION
DBZ-8299 - Upgrade Google BOM for PubSub

This PR upgrades the Google BOM to include the latest version of Google PubSub to allow support for OpenTelemetry W3C. The current version defaults to OpenCensus.