### PR TITLE
DBZ-8367: fix error message: show the correct config-path & format

### DIFF
--- a/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
@@ -278,9 +278,15 @@ public class DebeziumServer {
         }
         catch (NoSuchElementException e) {
             final String configFile = Paths.get(System.getProperty("user.dir"), "config", "application.properties").toString();
-            // CHECKSTYLE IGNORE check FOR NEXT 2 LINES
-            System.err.println(String.format("Failed to load mandatory config value '%s'. Please check you have a correct Debezium server config in %s or required "
-                    + "properties are defined via system or environment variables.", PROP_SINK_TYPE, configFile));
+            final String errorMessage = String
+                    .format("Failed to load mandatory config value '%s'. Please check you have a correct Debezium server config in %s or required "
+                            + "properties are defined via system or environment variables.", PROP_SINK_TYPE, configFile);
+
+            // Print to stderr in case of logging misconfiguration.
+            // CHECKSTYLE IGNORE check FOR NEXT 1 LINES
+            System.err.println(errorMessage);
+            LOGGER.error(errorMessage);
+
             Quarkus.asyncExit();
         }
         return config;

--- a/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
@@ -277,7 +277,7 @@ public class DebeziumServer {
             config.getValue(PROP_SINK_TYPE, String.class);
         }
         catch (NoSuchElementException e) {
-            final String configFile = Paths.get(System.getProperty("user.dir"), "conf", "application.properties").toString();
+            final String configFile = Paths.get(System.getProperty("user.dir"), "config", "application.properties").toString();
             // CHECKSTYLE IGNORE check FOR NEXT 2 LINES
             System.err.println(String.format("Failed to load mandatory config value '%s'. Please check you have a correct Debezium server config in %s or required "
                     + "properties are defined via system or environment variables.", PROP_SINK_TYPE, configFile));


### PR DESCRIPTION
When launching debezium-server via:
``` bash
java -jar ./debezium-server-dist/target/debezium-server-dist-3.0.0-SNAPSHOT-runner.jar io.debezium.server.Main
```

it errors out with the log-line:
```
Failed to load mandatory config value 'debezium.sink.type'. Please check you have a correct Debezium server config in /<redacted>/debezium/debezium-server/conf/application.properties or required properties are defined via system or environment variables.
```

This is broken in two ways:
- the printed path is wrong. quarkus loads application.properties from the `config` directory: https://quarkus.io/guides/config-reference
- the error message is logged via println. LOGGER should be used instead (otherwise depending on the logging-setup the message might be dropped - due to not being json)

This PR fixes both of these issues.
