### PR TITLE
DBZ-3226: Add step to verify the Debezium-server distribution

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -70,3 +70,63 @@ jobs:
         run: ./server/mvnw clean install -f core/pom.xml -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven build Debezium Server
         run: ./server/mvnw clean install -fae -f server/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -DskipNonCore
+      - name: Archive Debezium distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: debezium-dist-artifact
+          path: ./server/debezium-server-dist/target/debezium-server-dist*.tar.gz
+
+  validate-distribution:
+    name: Verify debezium-server distribution
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sink: [ redis ]
+    needs: build
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - name: Checkout Debezium Server repository
+        uses: actions/checkout@v4
+        with:
+          path: server
+      - name: Download Debezium distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: debezium-dist-artifact
+      - name: Unzip Debezium distribution
+        run: tar xf debezium-server-dist-*.tar.gz
+      - name: Validate sink '${{matrix.sink}}'
+        run: |
+          # Creating the distribution archives
+          DISTRIBUTION_FOLDER=./debezium-server
+          SINK=${{matrix.sink}}
+          CONFIG_FOLDER=./server/debezium-server-dist/src/test/resources/$SINK
+          
+          # Start Up dependant services
+          docker compose -f $CONFIG_FOLDER/docker-compose.yml up -d
+          
+          # Copy configuration file
+          cp $CONFIG_FOLDER/application.properties $DISTRIBUTION_FOLDER/config/application.properties
+          
+          # Run debezium server at background
+          docker run --name server-$SINK -d -v $DISTRIBUTION_FOLDER:/opt:z -p 8080:8080 --network debezium-backend -w /opt registry.access.redhat.com/ubi8/openjdk-21 ./run.sh
+          
+          # Verify
+          timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/q/health)" != "200" ]]; do sleep 5; done' || false
+      - name: Print logs
+        if: failure()
+        run: |
+          echo "Logs from dependant services:"
+          docker compose -f ./server/debezium-server-dist/src/test/resources/${{matrix.sink}}/docker-compose.yml logs
+          echo "Logs from Debezium server:"
+          docker logs server-${{matrix.sink}}
+      - name: Clean Up
+        if: always()
+        run: |
+          docker rm -f server-${{matrix.sink}}
+          docker compose -f ./server/debezium-server-dist/src/test/resources/${{matrix.sink}}/docker-compose.yml down

--- a/debezium-server-dist/src/test/resources/redis/application.properties
+++ b/debezium-server-dist/src/test/resources/redis/application.properties
@@ -1,0 +1,14 @@
+# Docker file used by GitHub actions to verify the debezium-server-dist works.
+debezium.sink.type=redis
+debezium.sink.redis.address=redis:6379
+debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
+debezium.source.offset.storage.file.filename=data/offsets.dat
+debezium.source.offset.flush.interval.ms=0
+debezium.source.database.hostname=postgres
+debezium.source.database.port=5432
+debezium.source.database.user=postgres
+debezium.source.database.password=postgres
+debezium.source.database.dbname=postgres
+debezium.source.topic.prefix=tutorial
+debezium.source.schema.include.list=inventory
+quarkus.log.console.json=false

--- a/debezium-server-dist/src/test/resources/redis/docker-compose.yml
+++ b/debezium-server-dist/src/test/resources/redis/docker-compose.yml
@@ -1,0 +1,23 @@
+# Docker file used by GitHub actions to verify the debezium-server-dist works.
+services:
+  postgres:
+    image: quay.io/debezium/example-postgres:3.0
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    networks:
+      - backend
+
+  redis:
+    image: bitnami/redis:7.0
+    ports:
+      - "6379:6379"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    networks:
+      - backend
+networks:
+  backend:
+    name: debezium-backend


### PR DESCRIPTION
Added a new job to validate the distribution works for each of the supported sinks. For now, I only added the "redis" sink. 

Fixes https://issues.redhat.com/browse/DBZ-3226