### PR TITLE
DBZ-8517: Bump Kinesis version to 2.17.241 to fix Jackson incompatibility when using the sink Kinesis

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.kinesis>2.13.13</version.kinesis>
+        <version.kinesis>2.17.241</version.kinesis>
         <version.sqs>2.13.13</version.sqs>
         <version.pubsub>26.17.0</version.pubsub>
         <version.pulsar>2.10.1</version.pulsar>


### PR DESCRIPTION
Bumping the Kinesis version to 2.17.241 will resolve the jackson incompatibility issue when running the Debezium server:

```
2024-12-11 11:25:23,166 ERROR [io.deb.ser.ConnectorLifecycle] (pool-7-thread-1) Connector completed: success = 'false', message = 'java.lang.NoSuchFieldError: Class com.fasterxml.jackson.databind.PropertyNamingStrategy does not have member field 'com.fasterxml.jackson.databind.PropertyNamingStrategy PASCAL_CASE_TO_CAMEL_CASE'', error = 'java.lang.NoSuchFieldError: Class com.fasterxml.jackson.databind.PropertyNamingStrategy does not have member field 'com.fasterxml.jackson.databind.PropertyNamingStrategy PASCAL_CASE_TO_CAMEL_CASE'': java.lang.NoSuchFieldError: Class com.fasterxml.jackson.databind.PropertyNamingStrategy does not have member field 'com.fasterxml.jackson.databind.PropertyNamingStrategy PASCAL_CASE_TO_CAMEL_CASE'
	at software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.<clinit>(EC2MetadataUtils.java:95)
	at software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider.getToken(InstanceProfileCredentialsProvider.java:83)
	at software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider.getCredentialsEndpointProvider(InstanceProfileCredentialsProvider.java:69)
	at software.amazon.awssdk.auth.credentials.HttpCredentialsProvider.refreshCredentials(HttpCredentialsProvider.java:74)
	at software.amazon.awssdk.utils.cache.CachedSupplier.refreshCache(CachedSupplier.java:132)
	at software.amazon.awssdk.utils.cache.CachedSupplier.get(CachedSupplier.java:89)
	at java.base/java.util.Optional.map(Optional.java:260)
	at software.amazon.awssdk.auth.credentials.HttpCredentialsProvider.resolveCredentials(HttpCredentialsProvider.java:146)
	at software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain.resolveCredentials(AwsCredentialsProviderChain.java:91)
	at software.amazon.awssdk.auth.credentials.internal.LazyAwsCredentialsProvider.resolveCredentials(LazyAwsCredentialsProvider.java:45)
	at software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.resolveCredentials(DefaultCredentialsProvider.java:104)
```

## How to reproduce
To reproduce this issue, follow the next steps:
1.- Build the Debezium server distribution: `./mvnw clean package -DskipITs -DskipTests -Passembly`
2.- Start Up postgres listening at localhost:5432, use the following docker-compose.yml as a reference: https://github.com/debezium/debezium-server/pull/140/files#diff-56a998a8165ad21afa94ccb494c4b08f843d129dfd9e897780e5d766f59c1aaeR103
3.- Copy the application properties of the distro folder to the Debezium target folder:

```
mkdir debezium-server-dist/target/config
cp debezium-server-dist/src/main/resources/distro/config/application.properties.example debezium-server-dist/target/config/application.properties
```

The relevant part of this application properties file is:
```
debezium.sink.type=kinesis
debezium.sink.kinesis.region=eu-central-1
```

4.- Then, when running the Debezium server: 
```
cd debezium-server-dist/target
chmod +x /classes/distro/run.sh
/classes/distro/run.sh
```

In main, the `run.sh` fails with the above exception.

Fixes https://issues.redhat.com/browse/DBZ-8517