### PR TITLE
V2.7.3.final nats publish async

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.2.Final</version>
+  <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.0-SNAPSHOT</version>
+  <version>2.7.3.Final</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.0.Final</version>
+  <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.0-SNAPSHOT</version>
+  <version>2.7.2.Final</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.0-SNAPSHOT</version>
+  <version>2.7.1.Final</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>
-  <version>2.7.1.Final</version>
+  <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server BOM</name>
     <packaging>jar</packaging>
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bom</artifactId>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -60,6 +60,10 @@
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>
+                    <artifactId>debezium-connector-mariadb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
                     <artifactId>debezium-connector-mysql</artifactId>
                 </dependency>
                 <dependency>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-dist/src/main/resources/distro/conf/metrics.yml
+++ b/debezium-server-dist/src/main/resources/distro/conf/metrics.yml
@@ -3,6 +3,23 @@ ssl: false
 lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 rules:
+- pattern: "kafka.producer<type=producer-metrics, client-id=([^>]+)><>([^:]+)"
+  name: "kafka_producer_metrics_$2"
+  type: GAUGE
+  labels:
+    client: "$1"
+- pattern: "kafka.producer<type=producer-node-metrics, client-id=([^>]+), node-id=([^>]+)><>([^:]+)"
+  name: "kafka_producer_node_metrics_$3"
+  type: GAUGE
+  labels:
+    client: "$1"
+    node: "$2"
+- pattern: "kafka.producer<type=producer-topic-metrics, client-id=([^>]+), topic=([^>]+)><>([^:]+)"
+  name: "kafka_producer_topic_metrics_$3"
+  type: GAUGE
+  labels:
+    client: "$1"
+    topic: "$2"
 - pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
   name: "kafka_connect_worker_metrics_$1"
   type: GAUGE

--- a/debezium-server-dist/src/main/resources/distro/conf/metrics.yml
+++ b/debezium-server-dist/src/main/resources/distro/conf/metrics.yml
@@ -3,14 +3,17 @@ ssl: false
 lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 rules:
-- pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
+- pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
   name: "kafka_connect_worker_metrics_$1"
-- pattern : "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
+  type: GAUGE
+- pattern: "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
   name: "kafka_connect_metrics_$2"
+  type: GAUGE
   labels:
     client: "$1"
 - pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^,]+), key=([^>]+)><>RowsScanned"
   name: "debezium_metrics_RowsScanned"
+  type: GAUGE
   labels:
     plugin: "$1"
     name: "$3"
@@ -18,6 +21,7 @@ rules:
     table: "$4"
 - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), database=([^>]+)>([^:]+)"
   name: "debezium_metrics_$6"
+  type: GAUGE
   labels:
     plugin: "$1"
     name: "$2"
@@ -26,6 +30,7 @@ rules:
     database: "$5"
 - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
   name: "debezium_metrics_$5"
+  type: GAUGE
   labels:
     plugin: "$1"
     name: "$2"
@@ -33,6 +38,7 @@ rules:
     context: "$4"
 - pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^>]+)>([^:]+)"
   name: "debezium_metrics_$4"
+  type: GAUGE
   labels:
     plugin: "$1"
     name: "$3"

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-eventhubs/pom.xml
+++ b/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-http/pom.xml
+++ b/debezium-server-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-infinispan/pom.xml
+++ b/debezium-server-infinispan/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/pom.xml
+++ b/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
+++ b/debezium-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
@@ -118,7 +118,12 @@ public class KafkaChangeConsumer extends BaseChangeConsumer implements DebeziumE
 
         for (Future<RecordMetadata> future : futures) {
             try {
-                future.get(waitMessageDeliveryTimeout, TimeUnit.MILLISECONDS);
+                if (waitMessageDeliveryTimeout == 0) {
+                    future.get();
+                }
+                else {
+                    future.get(waitMessageDeliveryTimeout, TimeUnit.MILLISECONDS);
+                }
             }
             catch (TimeoutException | ExecutionException e) {
                 throw new DebeziumException("Error while waiting for Kafka send operations to complete", e);

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-kinesis/pom.xml
+++ b/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server-nats-jetstream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.1.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.1.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.2.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.3.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.2.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pubsub/pom.xml
+++ b/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-pulsar/pom.xml
+++ b/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rabbitmq/pom.xml
+++ b/debezium-server-rabbitmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-redis/pom.xml
+++ b/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-rocketmq/pom.xml
+++ b/debezium-server-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server-sqs/pom.xml
+++ b/debezium-server-sqs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-system-tests/pom.xml
+++ b/debezium-system-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.2.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.3.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.1.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.2.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.1.Final</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:debezium/debezium-server.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium-server.git</developerConnection>
         <url>https://github.com/debezium/debezium-server</url>
-      <tag>v2.7.0.Final</tag>
+      <tag>v2.7.1.Final</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.7.0.Final</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.2.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:debezium/debezium-server.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium-server.git</developerConnection>
         <url>https://github.com/debezium/debezium-server</url>
-      <tag>v2.7.2.Final</tag>
+      <tag>v2.7.0.Final</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.3.Final</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:debezium/debezium-server.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium-server.git</developerConnection>
         <url>https://github.com/debezium/debezium-server</url>
-      <tag>v2.7.0.Final</tag>
+      <tag>v2.7.3.Final</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.1.Final</version>
+    <version>2.7.0-SNAPSHOT</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:debezium/debezium-server.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium-server.git</developerConnection>
         <url>https://github.com/debezium/debezium-server</url>
-      <tag>v2.7.1.Final</tag>
+      <tag>v2.7.0.Final</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>debezium-server</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.2.Final</version>
     <name>Debezium Server Parent</name>
     <packaging>pom</packaging>
 
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:debezium/debezium-server.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium-server.git</developerConnection>
         <url>https://github.com/debezium/debezium-server</url>
-      <tag>v2.7.0.Final</tag>
+      <tag>v2.7.2.Final</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
We found that sync publishing to nats has a very low throughput. We can only achieve 1k qps in production.
Proposing to publish to nats asynchronously to greatly improve the throughput.