### PR TITLE
DBZ-8735: Add support for Google Cloud Pub/Sub locational endpoints

### DIFF
--- a/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
+++ b/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
@@ -139,6 +139,9 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
     @ConfigProperty(name = PROP_PREFIX + "address")
     Optional<String> address;
 
+    @ConfigProperty(name = PROP_PREFIX + "region")
+    Optional<String> region;
+
     @Inject
     @CustomConsumerBuilder
     Instance<PublisherBuilder> customPublisherBuilder;
@@ -199,6 +202,9 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
 
                 if (address.isPresent()) {
                     builder.setChannelProvider(channelProvider).setCredentialsProvider(credentialsProvider);
+                } else if (region.isPresent()) {
+                    String endpoint = String.format("%s-pubsub.googleapis.com:443", region.get());
+                    builder.setEndpoint(endpoint);
                 }
 
                 return builder.build();

--- a/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
+++ b/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
@@ -202,7 +202,8 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
 
                 if (address.isPresent()) {
                     builder.setChannelProvider(channelProvider).setCredentialsProvider(credentialsProvider);
-                } else if (region.isPresent()) {
+                }
+                else if (region.isPresent()) {
                     String endpoint = String.format("%s-pubsub.googleapis.com:443", region.get());
                     builder.setEndpoint(endpoint);
                 }


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/DBZ-8735

This PR adds support for connecting to Google Cloud Pub/Sub locational endpoints by introducing a new configuration parameter `debezium.sink.pubsub.region`. 

The implementation leverages the standard `Publisher.Builder`'s `setEndpoint` method to establish connections to locational endpoints. 
ref: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/com.google.cloud.pubsub.v1.Publisher.Builder

The parameter is named 'region' instead of 'locational.endpoint' to maintain consistency with other sinks like Kinesis and PubSub Lite.