### PR TITLE
DBZ-8752 New property rabbitmq.routingKey.source for static, topic an…

### DIFF
--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqIT.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqIT.java
@@ -83,9 +83,12 @@ public class RabbitMqIT {
         connection = factory.newConnection();
         channel = connection.createChannel();
 
+        // With direct exchange and 'debezium.sink.rabbitmq.routingKey.source: topic'
+        // the routing key is expected to be the same as the topic name. Otherwise, the
+        // message won't reach the queue
         channel.exchangeDeclare(RabbitMqTestConfigSource.TOPIC_NAME, BuiltinExchangeType.DIRECT);
         String queue = channel.queueDeclare().getQueue();
-        channel.queueBind(queue, RabbitMqTestConfigSource.TOPIC_NAME, "");
+        channel.queueBind(queue, RabbitMqTestConfigSource.TOPIC_NAME, RabbitMqTestConfigSource.TOPIC_NAME);
 
         channel.basicConsume(queue, new DefaultConsumer(channel) {
             @Override

--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumerTest.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.rabbitmq;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine.RecordCommitter;
+import io.debezium.server.StreamNameMapper;
+
+class RabbitMqStreamChangeConsumerTest {
+
+    private static final int DELIVERY_MODE = 2;
+    private static final int ACK_TIMEOUT = 1000;
+
+    private Channel channelMock;
+    private StreamNameMapper streamNameMapperMock;
+    private ChangeEvent<Object, Object> eventMock;
+    private RecordCommitter<ChangeEvent<Object, Object>> committerMock;
+
+    private RabbitMqStreamChangeConsumer rabbitMqStreamChangeConsumer;
+
+    public static Stream<Arguments> testHandleBatch_StaticRoutingKeySourceParameters() {
+        return Stream.of(
+                Arguments.of("static-routing-key", "static-routing-key"),
+                Arguments.of(null, ""));
+    }
+
+    public static Stream<Arguments> testHandleBatch_KeyRoutingKeySourceParameters() {
+        return Stream.of(
+                Arguments.of("test-routing-key", "test-routing-key"),
+                Arguments.of(null, ""));
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        eventMock = mock(ChangeEvent.class);
+        channelMock = mock(Channel.class);
+        committerMock = mock(RecordCommitter.class);
+        streamNameMapperMock = mock(StreamNameMapper.class);
+
+        rabbitMqStreamChangeConsumer = new RabbitMqStreamChangeConsumer();
+        rabbitMqStreamChangeConsumer.channel = channelMock;
+        rabbitMqStreamChangeConsumer.setStreamNameMapper(streamNameMapperMock);
+        rabbitMqStreamChangeConsumer.deliveryMode = DELIVERY_MODE;
+        rabbitMqStreamChangeConsumer.ackTimeout = ACK_TIMEOUT;
+    }
+
+    @Test
+    void testHandleBatch_TopicRoutingKeySource() throws InterruptedException, IOException, TimeoutException {
+        // given
+        String topicName = "test-topic";
+        String payload = "test content";
+        List<ChangeEvent<Object, Object>> records = List.of(eventMock);
+
+        when(eventMock.destination()).thenReturn(topicName);
+        when(eventMock.value()).thenReturn(payload);
+        when(eventMock.headers()).thenReturn(List.of());
+        when(streamNameMapperMock.map(topicName)).thenReturn(topicName);
+
+        rabbitMqStreamChangeConsumer.exchange = Optional.of(topicName);
+        rabbitMqStreamChangeConsumer.routingKeySource = "topic";
+        rabbitMqStreamChangeConsumer.autoCreateRoutingKey = true;
+        rabbitMqStreamChangeConsumer.routingKeyDurable = true;
+        rabbitMqStreamChangeConsumer.routingKey = Optional.of("ignored");
+
+        // when
+        rabbitMqStreamChangeConsumer.handleBatch(records, committerMock);
+
+        // then
+        verify(channelMock).queueDeclare(topicName, true, false, false, null);
+
+        final AMQP.BasicProperties expectedProperties = new AMQP.BasicProperties.Builder()
+                .deliveryMode(DELIVERY_MODE)
+                .headers(Map.of())
+                .build();
+
+        verify(channelMock).basicPublish(topicName, topicName, expectedProperties, payload.getBytes());
+        verify(channelMock).waitForConfirmsOrDie(ACK_TIMEOUT);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testHandleBatch_StaticRoutingKeySourceParameters")
+    void testHandleBatch_StaticRoutingKeySource(String staticRoutingKey, String expectedRoutingKey) throws InterruptedException, IOException, TimeoutException {
+        // given
+        String topicName = "test-topic";
+        String payload = "test content";
+        List<ChangeEvent<Object, Object>> records = List.of(eventMock);
+
+        when(eventMock.destination()).thenReturn(topicName);
+        when(eventMock.value()).thenReturn(payload);
+        when(eventMock.headers()).thenReturn(List.of());
+        when(streamNameMapperMock.map(topicName)).thenReturn(topicName);
+
+        rabbitMqStreamChangeConsumer.exchange = Optional.of(topicName);
+        rabbitMqStreamChangeConsumer.routingKeySource = "static";
+        rabbitMqStreamChangeConsumer.routingKey = Optional.ofNullable(staticRoutingKey);
+
+        // when
+        rabbitMqStreamChangeConsumer.handleBatch(records, committerMock);
+
+        // then
+        verify(channelMock, never()).queueDeclare(any(), anyBoolean(), anyBoolean(), anyBoolean(), any());
+
+        final AMQP.BasicProperties expectedProperties = new AMQP.BasicProperties.Builder()
+                .deliveryMode(DELIVERY_MODE)
+                .headers(Map.of())
+                .build();
+
+        verify(channelMock).basicPublish(topicName, expectedRoutingKey, expectedProperties, payload.getBytes());
+        verify(channelMock).waitForConfirmsOrDie(ACK_TIMEOUT);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testHandleBatch_KeyRoutingKeySourceParameters")
+    void testHandleBatch_KeyRoutingKeySource(String routingKey, String expectedRoutingKey) throws InterruptedException, IOException, TimeoutException {
+        // given
+        String topicName = "test-topic";
+        String payload = "test content";
+        List<ChangeEvent<Object, Object>> records = List.of(eventMock);
+
+        when(eventMock.destination()).thenReturn(topicName);
+        when(eventMock.value()).thenReturn(payload);
+        when(eventMock.key()).thenReturn(routingKey);
+        when(eventMock.headers()).thenReturn(List.of());
+        when(streamNameMapperMock.map(topicName)).thenReturn(topicName);
+        when(streamNameMapperMock.map(routingKey)).thenReturn(routingKey);
+
+        rabbitMqStreamChangeConsumer.exchange = Optional.of(topicName);
+        rabbitMqStreamChangeConsumer.routingKeySource = "key";
+        rabbitMqStreamChangeConsumer.routingKey = Optional.of("ignored");
+
+        // when
+        rabbitMqStreamChangeConsumer.handleBatch(records, committerMock);
+
+        // then
+        verify(channelMock, never()).queueDeclare(any(), anyBoolean(), anyBoolean(), anyBoolean(), any());
+
+        final AMQP.BasicProperties expectedProperties = new AMQP.BasicProperties.Builder()
+                .deliveryMode(DELIVERY_MODE)
+                .headers(Map.of())
+                .build();
+
+        verify(channelMock).basicPublish(topicName, expectedRoutingKey, expectedProperties, payload.getBytes());
+        verify(channelMock).waitForConfirmsOrDie(ACK_TIMEOUT);
+    }
+}

--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqTestConfigSource.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqTestConfigSource.java
@@ -33,6 +33,7 @@ public class RabbitMqTestConfigSource extends TestConfigSource {
         rabbitmqConfig.put("debezium.source.topic.prefix", "testc");
         rabbitmqConfig.put("debezium.source.schema.include.list", "inventory");
         rabbitmqConfig.put("debezium.source.table.include.list", "inventory.customers");
+        rabbitmqConfig.put("debezium.sink.rabbitmq.routingKey.source", "topic");
         config = rabbitmqConfig;
     }
 


### PR DESCRIPTION
…d key states

Related issue: https://issues.redhat.com/browse/DBZ-8752

This PR adds support for a new property on the RabbitMQ sink `debezium.sink.rabbitmq.routingKey.source`. The motivation is to allow not only producing to desired exchange based on the outbox table, but also being able to dynamically select the routing key from the same table.

For that, this new property has the following possible values:

- `static` (default): which will obtain the routing key from `debezium.sink.rabbitmq.routingKey`
- `topic`: uses the value of the destination exchange as the routing key
- `key`: uses the record key as the routing key

`debezium.sink.rabbitmq.routingKeyFromTopicName` is now deprecated as `debezium.sink.rabbitmq.routingKey.source` with `topic` value does the same thing. If set to true, a warn will be emitted and the value of `debezium.sink.rabbitmq.routingKey.source` will become `topic` in order to provide backwards compatibility

