### PR TITLE
DBZ-8863 Explicitly include SnakeYAML, required by quarkus-config-yaml

### DIFF
--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
@@ -49,6 +49,12 @@
               <include>jakarta.xml.bind:*:*</include>
               <include>jakarta.activation:*:*</include>
               <include>jakarta.validation:*:*</include>
+              <!--
+              DBZ-8863 Explicitly include SnakeYAML, required by quarkus-config-yaml. It is being
+              incorrectly removed by transitive dependency filtering added for
+              debezium-connector-dse exclusion.
+              -->
+              <include>org.yaml:snakeyaml:*:*</include>
           </includes>
       </dependencySet>
       <dependencySet>

--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
@@ -44,6 +44,12 @@
               <include>jakarta.xml.bind:*:*</include>
               <include>jakarta.activation:*:*</include>
               <include>jakarta.validation:*:*</include>
+              <!--
+              DBZ-8863 Explicitly include SnakeYAML, required by quarkus-config-yaml. It is being
+              incorrectly removed by transitive dependency filtering added for
+              debezium-connector-dse exclusion.
+              -->
+              <include>org.yaml:snakeyaml:*:*</include>
           </includes>
       </dependencySet>
       <dependencySet>


### PR DESCRIPTION
See https://issues.redhat.com/projects/DBZ/issues/DBZ-8863

Relates to this conversation:  https://debezium.zulipchat.com/#narrow/channel/350571-community-dbz-server/topic/java.2Elang.2ENoClassDefFoundError.3A.20org.2Fyaml.2Fsnakeyaml  