### PR TITLE
DBZ-8893 Fix KinesisChangeConsumer so that it retries failed records.

### DIFF
--- a/debezium-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
+++ b/debezium-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
@@ -188,7 +188,7 @@ public class KinesisChangeConsumer extends BaseChangeConsumer implements Debeziu
                             for (int index = 0; index < putRecordsResults.size(); index++) {
                                 PutRecordsResultEntry entryResult = putRecordsResults.get(index);
                                 if (entryResult.errorCode() != null) {
-                                    failedRecordsList.add(putRecordsRequestEntryList.get(index));
+                                    failedRecordsList.add(batchRequest.get(index));
                                 }
                             }
                             batchRequest = failedRecordsList;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8893

Use batchRequest.get(index) instead of putRecordsRequestEntryList.get(index) when creating the list of failed records for retry. Add test for successive retries