### PR TITLE
DBZ-8906 Update Netty to 4.1.118.Final with Quarkus 3.15.4 LTS

### DIFF
--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -10,7 +10,7 @@
   <name>Debezium Server Pravega Sink Adapter</name>
   <properties>
     <!-- IMPORTANT: This must be aligned with the netty shipped with Quarkus, specified in debezium-build-parent -->
-    <netty.version>4.1.115.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8906