### PR TITLE
Change log level from trace to error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <!-- Support all log levels in Debezium Server -->
-        <quarkus.log.min-level>TRACE</quarkus.log.min-level>
+        <quarkus.log.min-level>ERROR</quarkus.log.min-level>
 
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>


### PR DESCRIPTION
Relevant ticket: https://getbridge.atlassian.net/jira/software/c/projects/PLT/list?filter=assignee%20%3D%20%22712020%3A28ce4012-1ed6-437c-b114-3af92ec2ecfc%22&selectedIssue=PLT-853

This PR aims to change the log levels in Debezium-server from TRACE to ERROR.
With this change, we should be able to see a normalized log troughput