### PR TITLE
DBZ-8985 Don't use wildcards in stream subjects

### DIFF
--- a/debezium-server-nats-jetstream/src/test/java/io/debezium/server/nats/jetstream/NatsJetStreamTestConfigSource.java
+++ b/debezium-server-nats-jetstream/src/test/java/io/debezium/server/nats/jetstream/NatsJetStreamTestConfigSource.java
@@ -20,6 +20,7 @@ public class NatsJetStreamTestConfigSource extends TestConfigSource {
         natsJetStreamTest.put("debezium.sink.nats-jetstream.url",
                 NatsJetStreamTestResourceLifecycleManager.getNatsContainerUrl());
         natsJetStreamTest.put("debezium.sink.nats-jetstream.create-stream", "true");
+        natsJetStreamTest.put("debezium.sink.nats-jetstream.subjects", "testc.inventory.customers");
         natsJetStreamTest.put("debezium.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
         natsJetStreamTest.put("debezium.source.topic.prefix", "testc");
         natsJetStreamTest.put("debezium.source.schema.include.list", "inventory");


### PR DESCRIPTION
If the subjects are not specified, `*.*.*` is used.

https://issues.redhat.com/browse/DBZ-8985