### PR TITLE
DBZ-9032 Align Netty to 4.1.119.Final used by Quarkus 3.20.1

### DIFF
--- a/debezium-server-pravega/pom.xml
+++ b/debezium-server-pravega/pom.xml
@@ -10,7 +10,7 @@
   <name>Debezium Server Pravega Sink Adapter</name>
   <properties>
     <!-- IMPORTANT: This must be aligned with the netty shipped with Quarkus, specified in debezium-build-parent -->
-    <netty.version>4.1.118.Final</netty.version>
+    <netty.version>4.1.119.Final</netty.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9032

Sibling PR of https://github.com/debezium/debezium/pull/6408