### PR TITLE
DBZ-9042 Pass the 'hostname.verification.enabled' option when creating a connection to Redis

### DIFF
--- a/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
+++ b/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
@@ -112,7 +112,7 @@ public class RedisStreamChangeConsumer extends BaseChangeConsumer
 
         RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(),
                 config.getUser(), config.getPassword(), config.getConnectionTimeout(), config.getSocketTimeout(),
-                config.isSslEnabled());
+                config.isSslEnabled(), config.isHostnameVerificationEnabled());
         client = redisConnection.getRedisClient(DEBEZIUM_REDIS_SINK_CLIENT_NAME, config.isWaitEnabled(),
                 config.getWaitTimeout(), config.isWaitRetryEnabled(), config.getWaitRetryDelay());
 


### PR DESCRIPTION
This configuration option is used when creating connections to Redis and is mainly used in the `debezium-storage-redis` module in `debezium`. 

There is one additional use of it by the `RedisStreamChangeConsumer` in `debezium-server-redis` which is updated as part of this commit.

See tracking issue [DBZ-9042](https://issues.redhat.com/browse/DBZ-9042)
See related [PR](https://github.com/debezium/debezium/pull/6421)  