### PR TITLE
DBZ-9082 Add options to specify custom keystore and truststore for Redis sink

### DIFF
--- a/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
+++ b/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
@@ -110,9 +110,7 @@ public class RedisStreamChangeConsumer extends BaseChangeConsumer
             };
         }
 
-        RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(),
-                config.getUser(), config.getPassword(), config.getConnectionTimeout(), config.getSocketTimeout(),
-                config.isSslEnabled(), config.isHostnameVerificationEnabled());
+        RedisConnection redisConnection = RedisConnection.getInstance(config);
         client = redisConnection.getRedisClient(DEBEZIUM_REDIS_SINK_CLIENT_NAME, config.isWaitEnabled(),
                 config.getWaitTimeout(), config.isWaitRetryEnabled(), config.getWaitRetryDelay());
 


### PR DESCRIPTION
_Open for review but should not be merged before the change in https://github.com/debezium/debezium/pull/6459 makes it in debezium-core._

The configuration options are used when creating connections to Redis and are mainly used in the debezium-storage-redis module in debezium.

There is one additional use in the RedisStreamChangeConsumer in debezium-server-redis which is updated as part of this commit.

This update uses a factory method that creates a RedisConnection directly from a shared configuration object (RedisCommonConfig). Previously, both Debezium and Debezium Server needed to duplicate any changes made to Redis connection parameters, leading to tight coupling and maintenance overhead. By centralizing connection creation through a common config, any updates to the Redis connection settings now only need to be made in Debezium.

See tracking issue [DBZ-9082](https://issues.redhat.com/browse/DBZ-9082)
See related https://github.com/debezium/debezium/pull/6459
