### PR TITLE
DBZ-9082 Add integration test for streaming to Redis sink with customSSL options

### DIFF
--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamIT.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.redis;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+import redis.clients.jedis.*;
+
+/**
+ *  Verifies that records can be streamed to Redis using Redis specific SSL configuration options.
+ */
+@QuarkusIntegrationTest
+@TestProfile(RedisSSLOptionsStreamTestProfile.class)
+public class RedisSSLOptionsStreamIT {
+
+    @Test
+    public void testRedisStream() throws Exception {
+        Jedis jedis = getJedisClient();
+
+        final int MESSAGE_COUNT = 4;
+        final String STREAM_NAME = "testc.inventory.customers";
+        final String HASH_NAME = "metadata:debezium:offsets";
+
+        TestUtils.awaitStreamLengthGte(jedis, STREAM_NAME, MESSAGE_COUNT);
+
+        Long streamLength = jedis.xlen(STREAM_NAME);
+        assertTrue("Redis Basic Stream Test Failed", streamLength == MESSAGE_COUNT);
+
+        // wait until the offsets are re-written
+        TestUtils.awaitHashSizeGte(jedis, HASH_NAME, 1);
+
+        Map<String, String> redisOffsets = jedis.hgetAll(HASH_NAME);
+        assertTrue(redisOffsets.size() > 0);
+
+        jedis.close();
+    }
+
+    private Jedis getJedisClient() {
+        HostAndPort address = HostAndPort.from(RedisSSLTestResourceLifecycleManager.getRedisContainerAddress());
+        URL keyStoreFile = RedisSSLOptionsStreamTestProfile.class.getClassLoader().getResource("ssl/client-keystore.p12");
+        URL trustStoreFile = RedisSSLOptionsStreamTestProfile.class.getClassLoader().getResource("ssl/client-truststore.p12");
+
+        // Unlike the regular SSL test, the keystore and truststore are not passed as system properties and need to be set explicitly
+        SslOptions sslOptions = SslOptions.builder()
+                .truststore(new File(trustStoreFile.getPath()), "secret".toCharArray())
+                .trustStoreType("PKCS12")
+                .keystore(new File(keyStoreFile.getPath()), "secret".toCharArray())
+                .keyStoreType("PKCS12")
+                .sslVerifyMode(SslVerifyMode.CA)
+                .build();
+        DefaultJedisClientConfig config = DefaultJedisClientConfig.builder()
+                .ssl(true)
+                .sslOptions(sslOptions)
+                .build();
+
+        return new Jedis(address, config);
+    }
+}

--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamIT.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamIT.java
@@ -16,7 +16,11 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 
-import redis.clients.jedis.*;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
 
 /**
  *  Verifies that records can be streamed to Redis using Redis specific SSL configuration options.

--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamTestProfile.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisSSLOptionsStreamTestProfile.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.redis;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.debezium.testing.testcontainers.PostgresTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RedisSSLOptionsStreamTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Arrays.asList(
+                new TestResourceEntry(PostgresTestResourceLifecycleManager.class),
+                new TestResourceEntry(RedisSSLTestResourceLifecycleManager.class));
+    }
+
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<String, String>();
+        URL keyStoreFile = RedisSSLOptionsStreamTestProfile.class.getClassLoader().getResource("ssl/client-keystore.p12");
+        URL trustStoreFile = RedisSSLOptionsStreamTestProfile.class.getClassLoader().getResource("ssl/client-truststore.p12");
+
+        // Instead of using javax.net.ssl properties (used in RedisSSLStreamIT), redis sink specific properties are used
+        config.put("debezium.sink.redis.ssl.truststore.path", trustStoreFile.getPath());
+        config.put("debezium.sink.redis.ssl.truststore.password", "secret");
+        config.put("debezium.sink.redis.ssl.truststore.type", "PKCS12");
+        config.put("debezium.sink.redis.ssl.keystore.path", keyStoreFile.getPath());
+        config.put("debezium.sink.redis.ssl.keystore.password", "secret");
+        config.put("debezium.sink.redis.ssl.keystore.type", "PKCS12");
+
+        config.put("debezium.source.offset.storage", "io.debezium.server.redis.RedisOffsetBackingStore");
+        config.put("debezium.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        return config;
+    }
+
+}


### PR DESCRIPTION
This change tests streaming data to a Redis sink configured with custom SSL options (keystore/truststore etc.)

The test is similar to an existing test (RedisSSLStreamIT) but specifies the SSL settings through debezium configuration properties specific to the Redis sink instead of system properties.

For more context see [DBZ-9082](https://issues.redhat.com/browse/DBZ-9082) and https://github.com/debezium/debezium/pull/6459