### PR TITLE
DBZ-9144 Reduce PubSub batch request byte threshold to 9.5MB

### DIFF
--- a/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
+++ b/debezium-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
@@ -104,7 +104,7 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
     @ConfigProperty(name = PROP_PREFIX + "batch.element.count.threshold", defaultValue = "100")
     Long maxBufferSize;
 
-    @ConfigProperty(name = PROP_PREFIX + "batch.request.byte.threshold", defaultValue = "10000000")
+    @ConfigProperty(name = PROP_PREFIX + "batch.request.byte.threshold", defaultValue = "9500000")
     Long maxBufferBytes;
 
     @ConfigProperty(name = PROP_PREFIX + "flowcontrol.enabled", defaultValue = "false")


### PR DESCRIPTION
See:https://issues.redhat.com/browse/DBZ-9144

If everyone happy I will update the default in the documentation also
