### PR TITLE
Implement dynamic partition key support for Azure Event Hub sink

### DIFF
--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
@@ -135,7 +135,7 @@ public class BatchManager {
      * This allows proper partitioning when no explicit partition ID or key is configured.
      */
     public void sendEventWithDynamicPartitionKey(EventData eventData, String partitionKey) {
-        String effectivePartitionKey = (partitionKey != null && !partitionKey.isEmpty()) ? partitionKey : "default";
+        String effectivePartitionKey = Strings.isNullOrBlank((partitionKey) ? partitionKey : "default";
 
         EventDataBatchProxy batch = dynamicPartitionKeyBatches.get(effectivePartitionKey);
 

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/BatchManager.java
@@ -15,6 +15,7 @@ import com.azure.messaging.eventhubs.EventHubProducerClient;
 import com.azure.messaging.eventhubs.models.CreateBatchOptions;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.Strings;
 
 public class BatchManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchManager.class);
@@ -135,7 +136,7 @@ public class BatchManager {
      * This allows proper partitioning when no explicit partition ID or key is configured.
      */
     public void sendEventWithDynamicPartitionKey(EventData eventData, String partitionKey) {
-        String effectivePartitionKey = Strings.isNullOrBlank((partitionKey) ? partitionKey : "default";
+        String effectivePartitionKey = Strings.isNullOrBlank(partitionKey) ? partitionKey : "default";
 
         EventDataBatchProxy batch = dynamicPartitionKeyBatches.get(effectivePartitionKey);
 

--- a/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/debezium-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -187,7 +187,7 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
                             throw new IndexOutOfBoundsException(
                                     String.format("Target partition id %d does not exist in target EventHub %s", targetPartitionId, eventHubName));
                         }
-                        
+
                         batchManager.sendEventToPartitionId(eventData, recordIndex, targetPartitionId);
                     }
                 }


### PR DESCRIPTION
When no explicit partitionId or partitionKey was configured, the system was using `record.partition()` which could be null, and then falling back to `BATCH_INDEX_FOR_NO_PARTITION_ID` (-1)
This caused all messages to have null partition IDs.

This PR modifies the partition selection logic to use `record.key()` as the partition key when no explicit partitioning is configured. This matches the behavior of other sinks like Kinesis, which already use `record.key()`