### PR TITLE
DBZ-9352 tiny fix to ensure JAVA_OPTS is correct when jmxremote.access/jmxremote.password are absent

### DIFF
--- a/debezium-server-dist/src/main/resources/distro/jmx/enable_jmx.sh
+++ b/debezium-server-dist/src/main/resources/distro/jmx/enable_jmx.sh
@@ -15,6 +15,6 @@ if [ -n "${JMX_HOST}" -a -n "${JMX_PORT}" ]; then
        -Dcom.sun.management.jmxremote.access.file=jmx/jmxremote.access \
        -Dcom.sun.management.jmxremote.password.file=jmx/jmxremote.password"
   else
-   export JAVA_OPT="${JAVA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+   export JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
   fi
 fi


### PR DESCRIPTION
DBZ-9352 tiny fix to ensure JAVA_OPTS is correct when jmxremote.access/jmxremote.password are absent