### PR TITLE
DBZ-9468 Don't exclude maven-artifact artifact

### DIFF
--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
@@ -20,7 +20,7 @@
             <exclude>javax.ws.rs:javax.ws.rs-api:*</exclude>
             <exclude>org.apache.kafka:connect-file:*</exclude>
             <exclude>org.glassfish.jersey.*:*:*</exclude>
-            <exclude>org.apache.maven:*:*</exclude>
+            <exclude>org.codehaus.plexus:*:*</exclude>
             <exclude>log4j:log4j:*</exclude>
             <exclude>ch.qos.reload4j:reload4j</exclude>
             <exclude>io.debezium:debezium-scripting</exclude>

--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
@@ -20,7 +20,7 @@
             <exclude>javax.ws.rs:javax.ws.rs-api:*</exclude>
             <exclude>org.apache.kafka:connect-file:*</exclude>
             <exclude>org.glassfish.jersey.*:*:*</exclude>
-            <exclude>org.apache.maven:*:*</exclude>
+            <exclude>org.codehaus.plexus:*:*</exclude>
             <exclude>log4j:log4j:*</exclude>
             <exclude>ch.qos.reload4j:reload4j</exclude>
     	    <exclude>io.debezium:debezium-scripting</exclude>


### PR DESCRIPTION
There is only one Apache Maven dependency, `maven-artifact` artifact, which is now required by Kafka 4.1.0.

https://issues.redhat.com/browse/DBZ-9468