### PR TITLE
DBZ-9477: support partition-scoped SQL Server connector metrics

### DIFF
--- a/debezium-server-core/src/main/java/io/debezium/server/DebeziumMetrics.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/DebeziumMetrics.java
@@ -37,7 +37,7 @@ public class DebeziumMetrics {
     private ObjectName streamingMetricsObjectName;
     private ObjectName streamingPartitionMetricsObjectName;
 
-    private static ObjectName getDebeziumMbean(String context, boolean partition) {
+    private static ObjectName getDebeziumMbean(String context, boolean partitioned) {
         ObjectName debeziumMbean = null;
 
         for (ObjectName mbean : mbeanServer.queryNames(null, null)) {
@@ -46,7 +46,7 @@ public class DebeziumMetrics {
                     && mbean.getCanonicalName().contains("type=connector-metrics")
                     && mbean.getCanonicalName().contains("context=" + context)
                     && (mbean.getCanonicalName().contains("debezium.sql_server:")
-                            ? mbean.getCanonicalName().contains("database=") == partition
+                            ? mbean.getCanonicalName().contains("database=") == partitioned
                             : true)) {
                 LOGGER.debug("Using {} MBean to get {} metrics", mbean, context);
                 debeziumMbean = mbean;

--- a/debezium-server-core/src/main/java/io/debezium/server/DebeziumMetrics.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/DebeziumMetrics.java
@@ -45,9 +45,7 @@ public class DebeziumMetrics {
             if (mbean.getCanonicalName().contains("debezium.")
                     && mbean.getCanonicalName().contains("type=connector-metrics")
                     && mbean.getCanonicalName().contains("context=" + context)
-                    && (mbean.getCanonicalName().contains("debezium.sql_server:")
-                            ? mbean.getCanonicalName().contains("database=") == partitioned
-                            : true)) {
+                    && checkConnectorSpecificTags(mbean, partitioned)) {
                 LOGGER.debug("Using {} MBean to get {} metrics", mbean, context);
                 debeziumMbean = mbean;
                 break;
@@ -58,6 +56,13 @@ public class DebeziumMetrics {
         Objects.requireNonNull(debeziumMbean, "Debezium MBean (context=" + context + ") not found!");
 
         return debeziumMbean;
+    }
+
+    private static boolean checkConnectorSpecificTags(ObjectName mbean, boolean partitioned) {
+        if (mbean.getCanonicalName().contains("debezium.sql_server:")) {
+            return mbean.getCanonicalName().contains("database=") == partitioned;
+        }
+        return true;
     }
 
     public ObjectName getSnapshotMetricsObjectName() {


### PR DESCRIPTION
Partial solution for https://issues.redhat.com/browse/DBZ-9477.
The problem is SQL Server connector metrics are split between several mbeans ([task- and partition-scoped](https://github.com/debezium/debezium/blob/v3.3.0.Beta1/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java)).
This PR is not a general solution for the problem but it allows to use DebeziumMetrics when SQL Server connector is configured with 1 task and 1 database (partition) and should not affect other connectors.
