### PR TITLE
debezium/dbz#1386 Fix infinite loop when batch contains only heartbeat messages in Redis sink

### DIFF
--- a/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
+++ b/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisStreamChangeConsumer.java
@@ -184,18 +184,28 @@ public class RedisStreamChangeConsumer extends BaseChangeConsumer
                         LOGGER.debug("Preparing a Redis Pipeline of {} records", clonedBatch.size());
 
                         List<SimpleEntry<String, Map<String, String>>> recordsMap = new ArrayList<>(clonedBatch.size());
+                        List<ChangeEvent<Object, Object>> processedRecords = new ArrayList<ChangeEvent<Object, Object>>();
                         for (ChangeEvent<Object, Object> record : clonedBatch) {
                             String destination = streamNameMapper.map(record.destination());
 
                             // Check if this is a heartbeat message that should be skipped
                             if (config.isSkipHeartbeatMessages() && destination.startsWith(heartbeatPrefix)) {
-                                // Mark as processed but don't add to Redis
+                                // Mark as processed and track for removal from clonedBatch
                                 committer.markProcessed(record);
+                                processedRecords.add(record);
                                 continue;
                             }
 
                             Map<String, String> recordMap = recordMapFunction.apply(record);
                             recordsMap.add(new SimpleEntry<>(destination, recordMap));
+                        }
+
+                        clonedBatch.removeAll(processedRecords);
+                        processedRecords.clear();
+
+                        if (clonedBatch.size() == 0) {
+                            completedSuccessfully = true;
+                            continue;
                         }
 
                         if (recordsMap.size() == 0) {
@@ -209,7 +219,6 @@ public class RedisStreamChangeConsumer extends BaseChangeConsumer
                             continue;
                         }
                         List<String> responses = client.xadd(recordsMap);
-                        List<ChangeEvent<Object, Object>> processedRecords = new ArrayList<ChangeEvent<Object, Object>>();
                         int index = 0;
                         int totalOOMResponses = 0;
 

--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisMemoryThresholdTest.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisMemoryThresholdTest.java
@@ -5,14 +5,25 @@
  */
 package io.debezium.server.redis;
 
+import java.lang.reflect.Field;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.DebeziumEngine.RecordCommitter;
+import io.debezium.engine.Header;
 import io.debezium.storage.redis.RedisClient;
 import io.debezium.util.Collect;
 
@@ -23,6 +34,57 @@ public class RedisMemoryThresholdTest {
     private static final long RECORD_SIZE = 2048L;
     private static final int BUFFER_SIZE = 500;
     private static final int RATE_PER_SECOND = 1000;
+
+    private static final String HEARTBEAT_PREFIX = "__debezium-heartbeat";
+
+    @Test
+    public void testHeartbeatOnlyBatchCompletesWithoutInfiniteLoop() throws Exception {
+        RedisStreamChangeConsumer consumer = new RedisStreamChangeConsumer();
+
+        Configuration config = Configuration.from(Collect.hashMapOf(
+                "debezium.sink.redis.address", "localhost:6379",
+                "debezium.sink.redis.skip.heartbeat.messages", "true",
+                "debezium.sink.redis.message.format", "compact"));
+        RedisStreamChangeConsumerConfig consumerConfig = new RedisStreamChangeConsumerConfig(config);
+
+        setField(consumer, RedisStreamChangeConsumer.class, "config", consumerConfig);
+        setField(consumer, RedisStreamChangeConsumer.class, "heartbeatPrefix", HEARTBEAT_PREFIX);
+        setField(consumer, RedisStreamChangeConsumer.class, "client", new RedisClientImpl(_10MB, _20MB));
+        setField(consumer, RedisStreamChangeConsumer.class, "redisMemoryThreshold",
+                new RedisMemoryThreshold(new RedisClientImpl(_10MB, _20MB), consumerConfig));
+
+        List<ChangeEvent<Object, Object>> batch = List.of(new HeartbeatChangeEvent(HEARTBEAT_PREFIX + ".testc"));
+        RecordCommitter<ChangeEvent<Object, Object>> committer = new NoOpRecordCommitter();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = executor.submit(() -> {
+            try {
+                consumer.handleBatch(batch, committer);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        try {
+            future.get(3, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException e) {
+            future.cancel(true);
+            Assertions.fail("handleBatch() did not complete within 3 seconds for a heartbeat-only batch " +
+                    "— infinite loop detected (DBZ-9353)");
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void setField(Object target, Class<?> declaringClass, String fieldName, Object value)
+            throws Exception {
+        Field field = declaringClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
 
     @Test
     public void testMemoryLimits() {
@@ -98,6 +160,63 @@ public class RedisMemoryThresholdTest {
         @Override
         public String clientList() {
             return null;
+        }
+    }
+
+    private static class HeartbeatChangeEvent implements ChangeEvent<Object, Object> {
+        private final String destination;
+
+        HeartbeatChangeEvent(String destination) {
+            this.destination = destination;
+        }
+
+        @Override
+        public Object key() {
+            return null;
+        }
+
+        @Override
+        public Object value() {
+            return null;
+        }
+
+        @Override
+        public String destination() {
+            return destination;
+        }
+
+        @Override
+        public Integer partition() {
+            return null;
+        }
+
+        @Override
+        public List<Header<Object>> headers() {
+            return Collections.emptyList();
+        }
+    }
+
+    private static class NoOpRecordCommitter implements RecordCommitter<ChangeEvent<Object, Object>> {
+        @Override
+        public void markProcessed(ChangeEvent<Object, Object> record) throws InterruptedException {
+        }
+
+        @Override
+        public void markProcessed(ChangeEvent<Object, Object> record, DebeziumEngine.Offsets offsets)
+                throws InterruptedException {
+        }
+
+        @Override
+        public void markBatchFinished() throws InterruptedException {
+        }
+
+        @Override
+        public DebeziumEngine.Offsets buildOffsets() {
+            return new DebeziumEngine.Offsets() {
+                @Override
+                public void set(String key, Object value) {
+                }
+            };
         }
     }
 }

--- a/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisMemoryThresholdTest.java
+++ b/debezium-server-redis/src/test/java/io/debezium/server/redis/RedisMemoryThresholdTest.java
@@ -14,8 +14,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +28,8 @@ import io.debezium.storage.redis.RedisClient;
 import io.debezium.util.Collect;
 
 public class RedisMemoryThresholdTest {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
     private static final String _5MB = String.valueOf(5 * 1024 * 1024);
     private static final String _10MB = String.valueOf(10 * 1024 * 1024);
     private static final String _20MB = String.valueOf(20 * 1024 * 1024);
@@ -56,27 +58,22 @@ public class RedisMemoryThresholdTest {
         List<ChangeEvent<Object, Object>> batch = List.of(new HeartbeatChangeEvent(HEARTBEAT_PREFIX + ".testc"));
         RecordCommitter<ChangeEvent<Object, Object>> committer = new NoOpRecordCommitter();
 
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<?> future = executor.submit(() -> {
+        Awaitility.await()
+                .atMost(3, TimeUnit.SECONDS)
+                .until(consume(consumer, batch, committer)::isDone);
+    }
+
+    private Future<?> consume(RedisStreamChangeConsumer consumer,
+                              List<ChangeEvent<Object, Object>> changeEvents,
+                              RecordCommitter<ChangeEvent<Object, Object>> committer) {
+        return executor.submit(() -> {
             try {
-                consumer.handleBatch(batch, committer);
+                consumer.handleBatch(changeEvents, committer);
             }
             catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
             }
         });
-
-        try {
-            future.get(3, TimeUnit.SECONDS);
-        }
-        catch (TimeoutException e) {
-            future.cancel(true);
-            Assertions.fail("handleBatch() did not complete within 3 seconds for a heartbeat-only batch " +
-                    "— infinite loop detected (DBZ-9353)");
-        }
-        finally {
-            executor.shutdownNow();
-        }
     }
 
     private static void setField(Object target, Class<?> declaringClass, String fieldName, Object value)


### PR DESCRIPTION
## Problem

When `skip.heartbeat.messages=true` and a batch contains only heartbeat records, `handleBatch()` enters an infinite loop. Heartbeat records were marked processed via `committer.markProcessed()` but never removed from `clonedBatch` because `processedRecords` was declared after the heartbeat-skip block. This kept `clonedBatch.size()` above 0 forever, so `completedSuccessfully` never became `true`. The `continue` in the heartbeat block also bypassed `delayStrategy.sleepWhen()`, making it a tight spin with no sleep.



## Fix

Moved `processedRecords` declaration to before the heartbeat-skip block, added heartbeat records to it, and called `clonedBatch.removeAll(processedRecords)` right after the for-loop. If `clonedBatch` is empty at that point, `completedSuccessfully` is set to `true` and the loop exits cleanly.



## Testing

Added a unit test in `RedisMemoryThresholdTest` that calls `handleBatch()` with a heartbeat-only batch using a mocked `RedisClient` (no Docker needed). The test confirmed the infinite loop before the fix and passes after.