### PR TITLE
debezium/dbz#1822 upgrade google libraries-bom to 26.74.0

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -15,7 +15,7 @@
         <version.kinesis>2.17.241</version.kinesis>
         <version.sqs>2.13.13</version.sqs>
         <version.sns>2.17.241</version.sns>
-        <version.pubsub>26.17.0</version.pubsub>
+        <version.pubsub>26.74.0</version.pubsub>
         <version.pulsar>4.1.2</version.pulsar>
         <version.milvus>2.5.4</version.milvus>
         <version.qdrant>1.14.0</version.qdrant>


### PR DESCRIPTION
Hi there,

This PR is to upgrade the google libraries-bom to the most recent version.  From my testing, this is the most recent version of libraries-bom that we can upgrade to without also upgrading protobuf to protobuf 4 (whose dependency is currently inherited from the Debezium parent).

I've done some testing on my side and all looks to be working fine.