### PR TITLE
debezium/dbz#1895 Add OpenTelemetry Java Agent support to Debezium Server distribution

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -25,6 +25,7 @@
         <version.stan>2.2.3</version.stan>
         <version.commons.logging>1.2</version.commons.logging>
         <version.jmx.exporter>1.0.1</version.jmx.exporter>
+        <version.otel.agent>2.27.0</version.otel.agent>
 
         <!-- Testing -->
         <version.junit.pioneer>2.0.1</version.junit.pioneer>
@@ -37,6 +38,12 @@
                 <groupId>io.prometheus.jmx</groupId>
                 <artifactId>jmx_prometheus_javaagent</artifactId>
                 <version>${version.jmx.exporter}</version>
+            </dependency>
+            <!-- OpenTelemetry Java Agent -->
+            <dependency>
+                <groupId>io.opentelemetry.javaagent</groupId>
+                <artifactId>opentelemetry-javaagent</artifactId>
+                <version>${version.otel.agent}</version>
             </dependency>
             <!-- Aligning versions/fixing scopes -->
             <dependency>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -323,6 +323,10 @@
                     <artifactId>jmx_prometheus_javaagent</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>io.opentelemetry.javaagent</groupId>
+                    <artifactId>opentelemetry-javaagent</artifactId>
+                </dependency>
+                <dependency>
                     <groupId>io.debezium</groupId>
                     <artifactId>debezium-connector-mariadb</artifactId>
                 </dependency>
@@ -403,6 +407,10 @@
                 <dependency>
                     <groupId>io.prometheus.jmx</groupId>
                     <artifactId>jmx_prometheus_javaagent</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.opentelemetry.javaagent</groupId>
+                    <artifactId>opentelemetry-javaagent</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>

--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution-prod.xml
@@ -30,6 +30,7 @@
             <exclude>io.debezium:debezium-connector-cassandra-5</exclude>
             <exclude>io.debezium:debezium-connector-dse</exclude>
             <exclude>io.prometheus.jmx:jmx_prometheus_javaagent:*</exclude>
+            <exclude>io.opentelemetry.javaagent:opentelemetry-javaagent:*</exclude>
 
             <!-- Exclude Oracle JDBC driver libraries -->
             <exclude>com.oracle.database.jdbc:ojdbc8:*</exclude>
@@ -65,6 +66,7 @@
           <useTransitiveFiltering>true</useTransitiveFiltering>
           <includes>
               <include>io.prometheus.jmx:jmx_prometheus_javaagent:*</include>
+              <include>io.opentelemetry.javaagent:opentelemetry-javaagent:*</include>
           </includes>
       </dependencySet>
       <dependencySet>

--- a/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
+++ b/debezium-server-dist/src/main/resources/assemblies/server-distribution.xml
@@ -30,6 +30,7 @@
             <exclude>io.debezium:debezium-connector-cassandra-5</exclude>
             <exclude>io.debezium:debezium-connector-dse</exclude>
             <exclude>io.prometheus.jmx:jmx_prometheus_javaagent:*</exclude>
+            <exclude>io.opentelemetry.javaagent:opentelemetry-javaagent:*</exclude>
           </excludes>
       </dependencySet>
       <dependencySet>
@@ -60,6 +61,7 @@
           <useTransitiveFiltering>true</useTransitiveFiltering>
           <includes>
               <include>io.prometheus.jmx:jmx_prometheus_javaagent:*</include>
+              <include>io.opentelemetry.javaagent:opentelemetry-javaagent:*</include>
           </includes>
       </dependencySet>
       <dependencySet>

--- a/debezium-server-dist/src/main/resources/distro/config/debezium-jmx-config-legacy.yaml
+++ b/debezium-server-dist/src/main/resources/distro/config/debezium-jmx-config-legacy.yaml
@@ -1,0 +1,377 @@
+---
+# OpenTelemetry JMX Metric Insight configuration for Debezium
+# Metric names use prefix debezium.metrics. with JMX attribute names
+# Context (streaming/snapshot) is extracted as a label from the ObjectName
+
+rules:
+  # Rule 1: Connectors with task and database dimensions (e.g., SQL Server, MongoDB)
+  - bean: debezium.*:type=connector-metrics,context=*,server=*,task=*,database=*
+    metricAttribute:
+      name: param(server)
+      task: param(task)
+      database: param(database)
+      context: param(context)
+    prefix: debezium.metrics.
+    mapping:
+      TotalNumberOfEventsSeen:
+        metric: TotalNumberOfEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfCreateEventsSeen:
+        metric: TotalNumberOfCreateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfUpdateEventsSeen:
+        metric: TotalNumberOfUpdateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfDeleteEventsSeen:
+        metric: TotalNumberOfDeleteEventsSeen
+        type: counter
+        unit: '{events}'
+      NumberOfErroneousEvents:
+        metric: NumberOfErroneousEvents
+        type: counter
+        unit: '{events}'
+      NumberOfEventsFiltered:
+        metric: NumberOfEventsFiltered
+        type: counter
+        unit: '{events}'
+      NumberOfUnchangedEventsSkipped:
+        metric: NumberOfUnchangedEventsSkipped
+        type: counter
+        unit: '{events}'
+        dropNegativeValues: true
+      NumberOfCommittedTransactions:
+        metric: NumberOfCommittedTransactions
+        type: counter
+        unit: '{transactions}'
+      MilliSecondsBehindSource:
+        metric: MilliSecondsBehindSource
+        type: gauge
+        unit: ms
+      MilliSecondsSinceLastEvent:
+        metric: MilliSecondsSinceLastEvent
+        type: gauge
+        unit: ms
+      QueueTotalCapacity:
+        metric: QueueTotalCapacity
+        type: gauge
+        unit: '{events}'
+      QueueRemainingCapacity:
+        metric: QueueRemainingCapacity
+        type: gauge
+        unit: '{events}'
+      MaxQueueSizeInBytes:
+        metric: MaxQueueSizeInBytes
+        type: gauge
+        unit: By
+      CurrentQueueSizeInBytes:
+        metric: CurrentQueueSizeInBytes
+        type: gauge
+        unit: By
+      SnapshotDurationInSeconds:
+        metric: SnapshotDurationInSeconds
+        type: gauge
+        unit: s
+      RemainingTableCount:
+        metric: RemainingTableCount
+        type: gauge
+        unit: '{tables}'
+      TotalTableCount:
+        metric: TotalTableCount
+        type: gauge
+        unit: '{tables}'
+      Connected:
+        metric: Connected
+        type: state
+        metricAttribute:
+          debezium.connected.status:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: SnapshotCompleted
+        type: state
+        metricAttribute:
+          debezium.snapshot.status:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: SnapshotAborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: SnapshotRunning
+        type: state
+        metricAttribute:
+          debezium.snapshot.running:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: SnapshotPaused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotPausedDurationInSeconds:
+        metric: SnapshotPausedDurationInSeconds
+        type: gauge
+        unit: s
+      SnapshotSkipped:
+        metric: SnapshotSkipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped:
+            skipped: 'true'
+            not_skipped: '*'
+
+  # Rule 2: Connectors with task dimension (no database)
+  - bean: debezium.*:type=connector-metrics,context=*,server=*,task=*
+    metricAttribute:
+      name: param(server)
+      task: param(task)
+      context: param(context)
+    prefix: debezium.metrics.
+    mapping:
+      TotalNumberOfEventsSeen:
+        metric: TotalNumberOfEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfCreateEventsSeen:
+        metric: TotalNumberOfCreateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfUpdateEventsSeen:
+        metric: TotalNumberOfUpdateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfDeleteEventsSeen:
+        metric: TotalNumberOfDeleteEventsSeen
+        type: counter
+        unit: '{events}'
+      NumberOfErroneousEvents:
+        metric: NumberOfErroneousEvents
+        type: counter
+        unit: '{events}'
+      NumberOfEventsFiltered:
+        metric: NumberOfEventsFiltered
+        type: counter
+        unit: '{events}'
+      NumberOfUnchangedEventsSkipped:
+        metric: NumberOfUnchangedEventsSkipped
+        type: counter
+        unit: '{events}'
+        dropNegativeValues: true
+      NumberOfCommittedTransactions:
+        metric: NumberOfCommittedTransactions
+        type: counter
+        unit: '{transactions}'
+      MilliSecondsBehindSource:
+        metric: MilliSecondsBehindSource
+        type: gauge
+        unit: ms
+      MilliSecondsSinceLastEvent:
+        metric: MilliSecondsSinceLastEvent
+        type: gauge
+        unit: ms
+      QueueTotalCapacity:
+        metric: QueueTotalCapacity
+        type: gauge
+        unit: '{events}'
+      QueueRemainingCapacity:
+        metric: QueueRemainingCapacity
+        type: gauge
+        unit: '{events}'
+      MaxQueueSizeInBytes:
+        metric: MaxQueueSizeInBytes
+        type: gauge
+        unit: By
+      CurrentQueueSizeInBytes:
+        metric: CurrentQueueSizeInBytes
+        type: gauge
+        unit: By
+      SnapshotDurationInSeconds:
+        metric: SnapshotDurationInSeconds
+        type: gauge
+        unit: s
+      RemainingTableCount:
+        metric: RemainingTableCount
+        type: gauge
+        unit: '{tables}'
+      TotalTableCount:
+        metric: TotalTableCount
+        type: gauge
+        unit: '{tables}'
+      Connected:
+        metric: Connected
+        type: state
+        metricAttribute:
+          debezium.connected.status:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: SnapshotCompleted
+        type: state
+        metricAttribute:
+          debezium.snapshot.status:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: SnapshotAborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: SnapshotRunning
+        type: state
+        metricAttribute:
+          debezium.snapshot.running:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: SnapshotPaused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotPausedDurationInSeconds:
+        metric: SnapshotPausedDurationInSeconds
+        type: gauge
+        unit: s
+      SnapshotSkipped:
+        metric: SnapshotSkipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped:
+            skipped: 'true'
+            not_skipped: '*'
+
+  # Rule 3: Connectors without task or database dimensions
+  - bean: debezium.*:type=connector-metrics,context=*,server=*
+    metricAttribute:
+      name: param(server)
+      context: param(context)
+    prefix: debezium.metrics.
+    mapping:
+      TotalNumberOfEventsSeen:
+        metric: TotalNumberOfEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfCreateEventsSeen:
+        metric: TotalNumberOfCreateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfUpdateEventsSeen:
+        metric: TotalNumberOfUpdateEventsSeen
+        type: counter
+        unit: '{events}'
+      TotalNumberOfDeleteEventsSeen:
+        metric: TotalNumberOfDeleteEventsSeen
+        type: counter
+        unit: '{events}'
+      NumberOfErroneousEvents:
+        metric: NumberOfErroneousEvents
+        type: counter
+        unit: '{events}'
+      NumberOfEventsFiltered:
+        metric: NumberOfEventsFiltered
+        type: counter
+        unit: '{events}'
+      NumberOfUnchangedEventsSkipped:
+        metric: NumberOfUnchangedEventsSkipped
+        type: counter
+        unit: '{events}'
+        dropNegativeValues: true
+      NumberOfCommittedTransactions:
+        metric: NumberOfCommittedTransactions
+        type: counter
+        unit: '{transactions}'
+      MilliSecondsBehindSource:
+        metric: MilliSecondsBehindSource
+        type: gauge
+        unit: ms
+      MilliSecondsSinceLastEvent:
+        metric: MilliSecondsSinceLastEvent
+        type: gauge
+        unit: ms
+      QueueTotalCapacity:
+        metric: QueueTotalCapacity
+        type: gauge
+        unit: '{events}'
+      QueueRemainingCapacity:
+        metric: QueueRemainingCapacity
+        type: gauge
+        unit: '{events}'
+      MaxQueueSizeInBytes:
+        metric: MaxQueueSizeInBytes
+        type: gauge
+        unit: By
+      CurrentQueueSizeInBytes:
+        metric: CurrentQueueSizeInBytes
+        type: gauge
+        unit: By
+      SnapshotDurationInSeconds:
+        metric: SnapshotDurationInSeconds
+        type: gauge
+        unit: s
+      RemainingTableCount:
+        metric: RemainingTableCount
+        type: gauge
+        unit: '{tables}'
+      TotalTableCount:
+        metric: TotalTableCount
+        type: gauge
+        unit: '{tables}'
+      Connected:
+        metric: Connected
+        type: state
+        metricAttribute:
+          debezium.connected.status:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: SnapshotCompleted
+        type: state
+        metricAttribute:
+          debezium.snapshot.status:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: SnapshotAborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: SnapshotRunning
+        type: state
+        metricAttribute:
+          debezium.snapshot.running:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: SnapshotPaused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotPausedDurationInSeconds:
+        metric: SnapshotPausedDurationInSeconds
+        type: gauge
+        unit: s
+      SnapshotSkipped:
+        metric: SnapshotSkipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped:
+            skipped: 'true'
+            not_skipped: '*'

--- a/debezium-server-dist/src/main/resources/distro/config/debezium-jmx-config.yaml
+++ b/debezium-server-dist/src/main/resources/distro/config/debezium-jmx-config.yaml
@@ -1,0 +1,468 @@
+---
+# OpenTelemetry JMX Metric Insight configuration for Debezium
+#
+# Metric names follow OTel naming conventions:
+#   debezium.{component}.{metric} — dot-separated, lowercase
+#
+# Units follow OTel/UCUM conventions:
+#   {event}, {transaction}, {table} (singular), s (seconds), By (bytes)
+#
+# The context dimension (streaming/snapshot) is extracted from the MBean ObjectName.
+
+rules:
+
+  # Rule 1: Connectors with task and database dimensions (e.g., SQL Server, MongoDB)
+  - bean: debezium.*:type=connector-metrics,context=*,server=*,task=*,database=*
+    metricAttribute:
+      debezium.logical.name: param(server)
+      debezium.task.id: param(task)
+      debezium.database: param(database)
+      debezium.context: param(context)
+    prefix: debezium.
+    mapping:
+
+      TotalNumberOfCreateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(create)
+      TotalNumberOfUpdateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(update)
+      TotalNumberOfDeleteEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(delete)
+
+      NumberOfErroneousEvents:
+        metric: event.erroneous.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events that resulted in an error during processing.
+      NumberOfEventsFiltered:
+        metric: event.filtered.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events excluded by the connector filter configuration.
+      NumberOfUnchangedEventsSkipped:
+        metric: event.skipped.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events skipped because they contained no data changes.
+        dropNegativeValues: true
+
+      NumberOfCommittedTransactions:
+        metric: transaction.committed.count
+        type: counter
+        unit: "{transaction}"
+        desc: The number of committed transactions processed from the source database.
+
+      MilliSecondsBehindSource:
+        metric: source.lag
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The time between a change occurring in the source database and Debezium processing it.
+      MilliSecondsSinceLastEvent:
+        metric: event.time_since_last
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The elapsed time since the last change event was processed.
+
+      QueueTotalCapacity:
+        metric: queue.limit
+        type: gauge
+        unit: "{event}"
+        desc: The configured maximum number of events the internal queue can hold.
+      QueueRemainingCapacity:
+        metric: queue.remaining_capacity
+        type: updowncounter
+        unit: "{event}"
+        desc: The number of available slots in the internal event queue.
+      MaxQueueSizeInBytes:
+        metric: queue.size.limit
+        type: gauge
+        unit: By
+        desc: The configured maximum size of the internal queue in bytes.
+      CurrentQueueSizeInBytes:
+        metric: queue.size
+        type: updowncounter
+        unit: By
+        desc: The current size of the internal event queue in bytes.
+
+      SnapshotDurationInSeconds:
+        metric: snapshot.duration
+        type: gauge
+        unit: s
+        desc: The total elapsed time of the current or most recent snapshot.
+      SnapshotPausedDurationInSeconds:
+        metric: snapshot.paused_duration
+        type: gauge
+        unit: s
+        desc: The total time the snapshot has spent in a paused state.
+      RemainingTableCount:
+        metric: snapshot.table.remaining_count
+        type: gauge
+        unit: "{table}"
+        desc: The number of tables remaining to be captured during the snapshot.
+      TotalTableCount:
+        metric: snapshot.table.count
+        type: gauge
+        unit: "{table}"
+        desc: The total number of tables included in the snapshot.
+
+      Connected:
+        metric: connection.status
+        type: state
+        metricAttribute:
+          debezium.connection.state:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: snapshot.completed
+        type: state
+        metricAttribute:
+          debezium.snapshot.completed.state:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: snapshot.aborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted.state:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: snapshot.running
+        type: state
+        metricAttribute:
+          debezium.snapshot.running.state:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: snapshot.paused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused.state:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotSkipped:
+        metric: snapshot.skipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped.state:
+            skipped: 'true'
+            not_skipped: '*'
+
+  # Rule 2: Connectors with task dimension (no database)
+  - bean: debezium.*:type=connector-metrics,context=*,server=*,task=*
+    metricAttribute:
+      debezium.logical.name: param(server)
+      debezium.task.id: param(task)
+      debezium.context: param(context)
+    prefix: debezium.
+    mapping:
+
+      TotalNumberOfCreateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(create)
+      TotalNumberOfUpdateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(update)
+      TotalNumberOfDeleteEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(delete)
+
+      NumberOfErroneousEvents:
+        metric: event.erroneous.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events that resulted in an error during processing.
+      NumberOfEventsFiltered:
+        metric: event.filtered.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events excluded by the connector filter configuration.
+      NumberOfUnchangedEventsSkipped:
+        metric: event.skipped.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events skipped because they contained no data changes.
+        dropNegativeValues: true
+
+      NumberOfCommittedTransactions:
+        metric: transaction.committed.count
+        type: counter
+        unit: "{transaction}"
+        desc: The number of committed transactions processed from the source database.
+
+      MilliSecondsBehindSource:
+        metric: source.lag
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The time between a change occurring in the source database and Debezium processing it.
+      MilliSecondsSinceLastEvent:
+        metric: event.time_since_last
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The elapsed time since the last change event was processed.
+
+      QueueTotalCapacity:
+        metric: queue.limit
+        type: gauge
+        unit: "{event}"
+        desc: The configured maximum number of events the internal queue can hold.
+      QueueRemainingCapacity:
+        metric: queue.remaining_capacity
+        type: updowncounter
+        unit: "{event}"
+        desc: The number of available slots in the internal event queue.
+      MaxQueueSizeInBytes:
+        metric: queue.size.limit
+        type: gauge
+        unit: By
+        desc: The configured maximum size of the internal queue in bytes.
+      CurrentQueueSizeInBytes:
+        metric: queue.size
+        type: updowncounter
+        unit: By
+        desc: The current size of the internal event queue in bytes.
+
+      SnapshotDurationInSeconds:
+        metric: snapshot.duration
+        type: gauge
+        unit: s
+        desc: The total elapsed time of the current or most recent snapshot.
+      SnapshotPausedDurationInSeconds:
+        metric: snapshot.paused_duration
+        type: gauge
+        unit: s
+        desc: The total time the snapshot has spent in a paused state.
+      RemainingTableCount:
+        metric: snapshot.table.remaining_count
+        type: gauge
+        unit: "{table}"
+        desc: The number of tables remaining to be captured during the snapshot.
+      TotalTableCount:
+        metric: snapshot.table.count
+        type: gauge
+        unit: "{table}"
+        desc: The total number of tables included in the snapshot.
+
+      Connected:
+        metric: connection.status
+        type: state
+        metricAttribute:
+          debezium.connection.state:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: snapshot.completed
+        type: state
+        metricAttribute:
+          debezium.snapshot.completed.state:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: snapshot.aborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted.state:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: snapshot.running
+        type: state
+        metricAttribute:
+          debezium.snapshot.running.state:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: snapshot.paused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused.state:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotSkipped:
+        metric: snapshot.skipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped.state:
+            skipped: 'true'
+            not_skipped: '*'
+
+  # Rule 3: Connectors without task or database dimensions
+  - bean: debezium.*:type=connector-metrics,context=*,server=*
+    metricAttribute:
+      debezium.logical.name: param(server)
+      debezium.context: param(context)
+    prefix: debezium.
+    mapping:
+
+      TotalNumberOfCreateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(create)
+      TotalNumberOfUpdateEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(update)
+      TotalNumberOfDeleteEventsSeen:
+        metric: event.count
+        type: counter
+        unit: "{event}"
+        desc: The number of change data capture events processed.
+        metricAttribute:
+          debezium.event.type: const(delete)
+
+      NumberOfErroneousEvents:
+        metric: event.erroneous.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events that resulted in an error during processing.
+      NumberOfEventsFiltered:
+        metric: event.filtered.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events excluded by the connector filter configuration.
+      NumberOfUnchangedEventsSkipped:
+        metric: event.skipped.count
+        type: counter
+        unit: "{event}"
+        desc: The number of events skipped because they contained no data changes.
+        dropNegativeValues: true
+
+      NumberOfCommittedTransactions:
+        metric: transaction.committed.count
+        type: counter
+        unit: "{transaction}"
+        desc: The number of committed transactions processed from the source database.
+
+      MilliSecondsBehindSource:
+        metric: source.lag
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The time between a change occurring in the source database and Debezium processing it.
+      MilliSecondsSinceLastEvent:
+        metric: event.time_since_last
+        type: gauge
+        sourceUnit: ms
+        unit: s
+        desc: The elapsed time since the last change event was processed.
+
+      QueueTotalCapacity:
+        metric: queue.limit
+        type: gauge
+        unit: "{event}"
+        desc: The configured maximum number of events the internal queue can hold.
+      QueueRemainingCapacity:
+        metric: queue.remaining_capacity
+        type: updowncounter
+        unit: "{event}"
+        desc: The number of available slots in the internal event queue.
+      MaxQueueSizeInBytes:
+        metric: queue.size.limit
+        type: gauge
+        unit: By
+        desc: The configured maximum size of the internal queue in bytes.
+      CurrentQueueSizeInBytes:
+        metric: queue.size
+        type: updowncounter
+        unit: By
+        desc: The current size of the internal event queue in bytes.
+
+      SnapshotDurationInSeconds:
+        metric: snapshot.duration
+        type: gauge
+        unit: s
+        desc: The total elapsed time of the current or most recent snapshot.
+      SnapshotPausedDurationInSeconds:
+        metric: snapshot.paused_duration
+        type: gauge
+        unit: s
+        desc: The total time the snapshot has spent in a paused state.
+      RemainingTableCount:
+        metric: snapshot.table.remaining_count
+        type: gauge
+        unit: "{table}"
+        desc: The number of tables remaining to be captured during the snapshot.
+      TotalTableCount:
+        metric: snapshot.table.count
+        type: gauge
+        unit: "{table}"
+        desc: The total number of tables included in the snapshot.
+
+      Connected:
+        metric: connection.status
+        type: state
+        metricAttribute:
+          debezium.connection.state:
+            connected: 'true'
+            disconnected: '*'
+      SnapshotCompleted:
+        metric: snapshot.completed
+        type: state
+        metricAttribute:
+          debezium.snapshot.completed.state:
+            completed: 'true'
+            not_completed: '*'
+      SnapshotAborted:
+        metric: snapshot.aborted
+        type: state
+        metricAttribute:
+          debezium.snapshot.aborted.state:
+            aborted: 'true'
+            not_aborted: '*'
+      SnapshotRunning:
+        metric: snapshot.running
+        type: state
+        metricAttribute:
+          debezium.snapshot.running.state:
+            running: 'true'
+            not_running: '*'
+      SnapshotPaused:
+        metric: snapshot.paused
+        type: state
+        metricAttribute:
+          debezium.snapshot.paused.state:
+            paused: 'true'
+            not_paused: '*'
+      SnapshotSkipped:
+        metric: snapshot.skipped
+        type: state
+        metricAttribute:
+          debezium.snapshot.skipped.state:
+            skipped: 'true'
+            not_skipped: '*'

--- a/debezium-server-dist/src/main/resources/distro/lib_metrics/enable_otel_agent.sh
+++ b/debezium-server-dist/src/main/resources/distro/lib_metrics/enable_otel_agent.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# To attach the OpenTelemetry Java Agent, set OTEL_ENABLED=true
+# The SDK is disabled by default even when attached. To activate telemetry
+# collection, also set OTEL_SDK_DISABLED=false
+
+if [ "${OTEL_ENABLED}" = "true" ]; then
+  export OTEL_SDK_DISABLED=${OTEL_SDK_DISABLED:-true}
+  export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-"http://localhost:4318"}
+  export OTEL_JMX_CONFIG=${OTEL_JMX_CONFIG:-"config/debezium-jmx-config.yaml"}
+
+  OTEL_AGENT_JAR=$(find lib_metrics -name "opentelemetry-javaagent-*.jar")
+  export JAVA_OPTS="-javaagent:${OTEL_AGENT_JAR} ${JAVA_OPTS}"
+fi

--- a/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server-dist/src/main/resources/distro/run.sh
@@ -49,6 +49,7 @@ fi
 
 source ./jmx/enable_jmx.sh
 source ./lib_metrics/enable_exporter.sh
+source ./lib_metrics/enable_otel_agent.sh
 
 exec "$JAVA_BINARY" $DEBEZIUM_OPTS $JAVA_OPTS -cp \
     $RUNNER$PATH_SEP$LIB_CONFIG_PATH$PATH_SEP$LIB_PATH io.debezium.server.Main


### PR DESCRIPTION
Closes: https://github.com/debezium/dbz/issues/1895

 Adds native OpenTelemetry Java Agent support to the Debezium Server distribution.

  - The agent JAR is bundled in `lib_metrics/` and activated via `OTEL_ENABLED=true`
  - The SDK is disabled by default (`OTEL_SDK_DISABLED=true`) until explicitly activated, giving users two-level control
  - A JMX metric config (`debezium-jmx-config.yaml`) maps Debezium MBean attributes to OTel-compliant metric names (e.g., debezium.event.count,
  debezium.source.lag), following OTel naming conventions, unit standards, and including descriptions
  - A legacy config (`debezium-jmx-config-legacy.yaml`) with original JMX attribute names is also provided

  The corresponding container image changes (simplified Dockerfile that no longer downloads the agent separately or patches run.sh via sed) are in
  https://github.com/debezium/container-images/pull/491.

  Known limitations

  - RowsScanned (Map attribute): The OTel JMX YAML config does not support expanding Map<String, Long> MBean attributes into per-key metrics. The JMX Prometheus
   exporter does this automatically.
  - plugin label: No way to extract the MBean domain (connector type) in the YAML config. Must be injected externally via `OTEL_RESOURCE_ATTRIBUTES`.

Metrics output with OTel agent
  
```text
# HELP debezium_connection_status_ratio Connected
# TYPE debezium_connection_status_ratio gauge
debezium_connection_status_ratio{debezium_connection_state="connected",debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 1.0
debezium_connection_status_ratio{debezium_connection_state="disconnected",debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_event_count_total The number of change data capture events processed.
# TYPE debezium_event_count_total counter
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="snapshot",debezium_event_type="create",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="snapshot",debezium_event_type="delete",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="snapshot",debezium_event_type="update",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="streaming",debezium_event_type="create",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="streaming",debezium_event_type="delete",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_count_total{debezium_connector_name="inventory",debezium_context="streaming",debezium_event_type="update",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_event_erroneous_count_total The number of events that resulted in an error during processing.
# TYPE debezium_event_erroneous_count_total counter
debezium_event_erroneous_count_total{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_erroneous_count_total{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_event_filtered_count_total The number of events excluded by the connector filter configuration.
# TYPE debezium_event_filtered_count_total counter
debezium_event_filtered_count_total{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_event_filtered_count_total{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_event_time_since_last_seconds The elapsed time since the last change event was processed.
# TYPE debezium_event_time_since_last_seconds gauge
debezium_event_time_since_last_seconds{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 58.833
debezium_event_time_since_last_seconds{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} -0.001
# HELP debezium_queue_limit The configured maximum number of events the internal queue can hold.
# TYPE debezium_queue_limit gauge
debezium_queue_limit{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 8192.0
debezium_queue_limit{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 8192.0
# HELP debezium_queue_remaining_capacity The number of available slots in the internal event queue.
# TYPE debezium_queue_remaining_capacity gauge
debezium_queue_remaining_capacity{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 8192.0
debezium_queue_remaining_capacity{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 8192.0
# HELP debezium_queue_size_bytes The current size of the internal event queue in bytes.
# TYPE debezium_queue_size_bytes gauge
debezium_queue_size_bytes{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_queue_size_bytes{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_queue_size_limit_bytes The configured maximum size of the internal queue in bytes.
# TYPE debezium_queue_size_limit_bytes gauge
debezium_queue_size_limit_bytes{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_queue_size_limit_bytes{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_aborted_ratio SnapshotAborted
# TYPE debezium_snapshot_aborted_ratio gauge
debezium_snapshot_aborted_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_aborted_state="aborted",otel_scope_name="io.opentelemetry.jmx"} 0.0
debezium_snapshot_aborted_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_aborted_state="not_aborted",otel_scope_name="io.opentelemetry.jmx"} 1.0
# HELP debezium_snapshot_completed_ratio SnapshotCompleted
# TYPE debezium_snapshot_completed_ratio gauge
debezium_snapshot_completed_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_completed_state="completed",otel_scope_name="io.opentelemetry.jmx"} 1.0
debezium_snapshot_completed_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_completed_state="not_completed",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_duration_seconds The total elapsed time of the current or most recent snapshot.
# TYPE debezium_snapshot_duration_seconds gauge
debezium_snapshot_duration_seconds{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_paused_duration_seconds The total time the snapshot has spent in a paused state.
# TYPE debezium_snapshot_paused_duration_seconds gauge
debezium_snapshot_paused_duration_seconds{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_paused_ratio SnapshotPaused
# TYPE debezium_snapshot_paused_ratio gauge
debezium_snapshot_paused_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_paused_state="not_paused",otel_scope_name="io.opentelemetry.jmx"} 1.0
debezium_snapshot_paused_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_paused_state="paused",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_running_ratio SnapshotRunning
# TYPE debezium_snapshot_running_ratio gauge
debezium_snapshot_running_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_running_state="not_running",otel_scope_name="io.opentelemetry.jmx"} 1.0
debezium_snapshot_running_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_running_state="running",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_skipped_ratio SnapshotSkipped
# TYPE debezium_snapshot_skipped_ratio gauge
debezium_snapshot_skipped_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_skipped_state="not_skipped",otel_scope_name="io.opentelemetry.jmx"} 1.0
debezium_snapshot_skipped_ratio{debezium_connector_name="inventory",debezium_context="snapshot",debezium_snapshot_skipped_state="skipped",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_snapshot_table_count The total number of tables included in the snapshot.
# TYPE debezium_snapshot_table_count gauge
debezium_snapshot_table_count{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 5.0
# HELP debezium_snapshot_table_remaining_count The number of tables remaining to be captured during the snapshot.
# TYPE debezium_snapshot_table_remaining_count gauge
debezium_snapshot_table_remaining_count{debezium_connector_name="inventory",debezium_context="snapshot",otel_scope_name="io.opentelemetry.jmx"} 0.0
# HELP debezium_source_lag_seconds The time between a change occurring in the source database and Debezium processing it.
# TYPE debezium_source_lag_seconds gauge
debezium_source_lag_seconds{debezium_connector_name="inventory",debezium_context="streaming",otel_scope_name="io.opentelemetry.jmx"} -0.001
# HELP debezium_transaction_committed_count_total The number of committed transactions processed from the source database.
# TYPE debezium_transaction_committed_count_total counter
```  