### PR TITLE
debezium/dbz#1961 Enable component descriptor for jdbc sink

### DIFF
--- a/debezium-server-jdbc/pom.xml
+++ b/debezium-server-jdbc/pom.xml
@@ -118,6 +118,10 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-schema-generator</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/debezium-server-jdbc/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
+++ b/debezium-server-jdbc/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
@@ -1,0 +1,1 @@
+io.debezium.server.jdbc.JdbcChangeConsumer


### PR DESCRIPTION
Fixes: debezium/dbz#1961