### PR TITLE
debezium/dbz#1185 Sink connector framework pt.2.2 - add shared sink connector framework for JDBC sink connector

### DIFF
--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -113,6 +113,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <version>${version.strimzi-test-container}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
@@ -170,6 +182,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerSchemaRegistryProfile.java
+++ b/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerSchemaRegistryProfile.java
@@ -8,7 +8,6 @@ package io.debezium.server;
 import java.util.Collections;
 import java.util.List;
 
-import io.debezium.testing.testcontainers.SchemaRegistryTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTestProfile;
 
 public class DebeziumServerSchemaRegistryProfile implements QuarkusTestProfile {

--- a/debezium-server-core/src/test/java/io/debezium/server/SchemaRegistryContainer.java
+++ b/debezium-server-core/src/test/java/io/debezium/server/SchemaRegistryContainer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.strimzi.test.container.StrimziKafkaCluster;
+
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = "quay.io/debezium/confluentinc-cp-schema-registry:6.0.2";
+    private static final DockerImageName SCHEMA_REGISTRY_DOCKER_IMAGE = DockerImageName.parse(SCHEMA_REGISTRY_DOCKER_IMAGE_NAME)
+            .asCompatibleSubstituteFor("confluentinc/cp-schema-registry");
+    private static final Integer SCHEMA_REGISTRY_EXPOSED_PORT = 8081;
+
+    SchemaRegistryContainer() {
+        super(SCHEMA_REGISTRY_DOCKER_IMAGE);
+        addExposedPorts(SCHEMA_REGISTRY_EXPOSED_PORT);
+    }
+
+    public SchemaRegistryContainer withKafka(StrimziKafkaCluster kafkaCluster) {
+        final GenericContainer<?> kafkaContainer = kafkaCluster.getNodes().stream().findFirst().get();
+        withNetwork(kafkaContainer.getNetwork());
+        withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry");
+        withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081");
+        withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", kafkaCluster.getNetworkBootstrapServers());
+        return self();
+    }
+}

--- a/debezium-server-core/src/test/java/io/debezium/server/SchemaRegistryTestResourceLifecycleManager.java
+++ b/debezium-server-core/src/test/java/io/debezium/server/SchemaRegistryTestResourceLifecycleManager.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import io.debezium.testing.testcontainers.testhelper.TestInfrastructureHelper;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.strimzi.test.container.StrimziKafkaCluster;
+
+public class SchemaRegistryTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegistryTestResourceLifecycleManager.class);
+
+    private static final Integer PORT = 8081;
+
+    public static final StrimziKafkaCluster KAFKA_CLUSTER = TestInfrastructureHelper.getKafkaCluster();
+
+    private static final SchemaRegistryContainer SCHEMA_REGISTRY = new SchemaRegistryContainer()
+            .withNetwork(TestInfrastructureHelper.getNetwork())
+            .withKafka(KAFKA_CLUSTER)
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+            .dependsOn(KAFKA_CLUSTER)
+            .withStartupTimeout(Duration.ofSeconds(90));
+
+    @Override
+    public Map<String, String> start() {
+        Startables.deepStart(Stream.of(KAFKA_CLUSTER, SCHEMA_REGISTRY)).join();
+
+        Map<String, String> params = new ConcurrentHashMap<>();
+        params.put("debezium.format.schema.registry.url", getSchemaRegistryUrl());
+
+        return params;
+    }
+
+    @Override
+    public void stop() {
+        try {
+            if (SCHEMA_REGISTRY != null) {
+                SCHEMA_REGISTRY.stop();
+            }
+        }
+        catch (Exception e) {
+            // ignored
+        }
+    }
+
+    private static String getSchemaRegistryUrl() {
+        return "http://" + SCHEMA_REGISTRY.getHost() + ":" + SCHEMA_REGISTRY.getMappedPort(PORT);
+    }
+}

--- a/debezium-server-jdbc/src/main/java/io/debezium/server/jdbc/JdbcChangeConsumer.java
+++ b/debezium-server-jdbc/src/main/java/io/debezium/server/jdbc/JdbcChangeConsumer.java
@@ -120,8 +120,6 @@ public class JdbcChangeConsumer extends BaseChangeConsumer implements DebeziumSe
                     UUID.randomUUID(),
                     new java.util.HashMap<>());
 
-            metrics.connected(true);
-
             this.changeEventSink = new JdbcChangeEventSink(
                     jdbcConfig, session, dialect, recordWriter, connectorContext, metrics);
 


### PR DESCRIPTION
During the sink connector framework work I had to upgrade `debezium-testing-testcontainers` to the StrimziKafkaCluster. This broke the DS build.
I discovered that the  SchemaRegistryContainer (based on Confluent Platform) and the related LifecycleManager were only used in DS, thus moving it here.

* Moving SchemaRegistryContainer and SchemaRegistryTestResourceLifecycleManager to Debezium Server repository
* NoClassDefFoundError: io/strimzi/test/container/StrimziKafkaCluster$StrimziKafkaClusterBuilder in Debezium Server after update to StrimziKafkaCluster

relates to debezium/dbz#1185
relates to debezium/debezium#7411
