### PR TITLE
Add ZeroBus sink for Debezium Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,79 @@ mvn clean package -DskipITs -DskipTests -Passembly -Pcustom-distribution,sink-ka
 - `sink-milvus` - Milvus
 - `sink-qdrant` - Qdrant
 - `sink-instructlab` - InstructLab
+- `sink-zerobus` - ZeroBus
 
 This approach allows you to create smaller, more focused distributions that only include the sink modules you actually need.
+
+#### ZeroBus Sink
+
+The ZeroBus sink is a native Debezium Server sink. It is selected with `debezium.sink.type=zerobus`
+and writes Debezium Server change events through the Databricks ZeroBus Java SDK's JSON, protobuf,
+or Arrow stream APIs.
+It does not use the Kafka Connect runtime, Kafka brokers, Kafka producer APIs, or Kafka Connect SMTs.
+
+Example configuration:
+
+```properties
+debezium.sink.type=zerobus
+debezium.sink.zerobus.endpoint=https://zerobus.example
+debezium.sink.zerobus.workspace.url=https://dbc-a1b2c3d4-e5f6.cloud.databricks.com
+debezium.sink.zerobus.authentication.type=oauth2
+debezium.sink.zerobus.authentication.oauth2.client-id=${ZEROBUS_CLIENT_ID}
+debezium.sink.zerobus.authentication.oauth2.client-secret=${ZEROBUS_CLIENT_SECRET}
+debezium.sink.zerobus.record.format=json
+debezium.sink.zerobus.max.inflight.batches=1000
+debezium.sink.zerobus.idempotency.mode=source
+debezium.sink.zerobus.tombstone.handling.mode=event
+debezium.sink.zerobus.table.mapping.mode=source
+debezium.sink.zerobus.table.mapping.default.catalog=main
+debezium.sink.zerobus.table.mapping.default.schema=bronze
+```
+
+For a custom distribution that includes only the ZeroBus sink:
+
+```bash
+mvn clean package -DskipITs -DskipTests -Passembly -Pcustom-distribution,sink-zerobus
+```
+
+For local ZeroBus module work, Java 25 can be selected explicitly:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home \
+  mvn -pl debezium-server-zerobus test -DskipITs -Dquick -DskipTests=false -Dformat.skip=true
+```
+
+The native sink routes records to Unity Catalog table identifiers using source, explicit, or regex
+mapping modes implemented inside the sink. Regex mapping is not Kafka Connect `RegexRouter`; it is
+native sink routing for teams migrating from topic-oriented deployments.
+
+The ZeroBus envelope contains `target_table`, `destination`, `partition`, `operation`,
+`idempotency_key`, `key`, `value`, `source_position`, and `headers` in JSON, protobuf, or Arrow
+mode. With
+`idempotency.mode=source`, the envelope-level key is derived from Debezium destination, partition,
+key, and the underlying `SourceRecord` source partition/offset when available, so LSN/transaction
+ordering metadata is carried into the ZeroBus payload. Header fingerprints are used only as a
+fallback for non-embedded events. Protobuf and Arrow modes use the same stable envelope shape; typed
+source-table protobuf or source-table-shaped Arrow rows remain a future schema-evolution track.
+Delete events are inferred from Debezium envelope `op=d`; null-value tombstones are distinct and can
+be emitted as `operation=tombstone` or dropped. The sink writes a batch, waits for the returned
+ZeroBus SDK offset with `waitForOffset(...)`, and only then marks Debezium records processed.
+
+The first upstream contribution packet is documented in
+`debezium-server-zerobus/UPSTREAM_CONTRIBUTION_PACKET.md`.
+
+The ZeroBus Kafka-compatible API recipe is a separate compatibility path for deployments that still
+run Kafka Connect. That recipe uses Kafka producer-compatible settings such as:
+
+```properties
+producer.override.bootstrap.servers=<zerobus-kafka-compatible-endpoint>
+producer.override.sasl.login.callback.handler.class=<zerobus-oauth-handler>
+transforms=<RegexRouter mapping>
+tombstones.on.delete=false
+```
+
+This removes Kafka broker from the CDC data path, but still runs Kafka Connect and still uses Kafka
+producer-compatible APIs. It is not the native Debezium Server ZeroBus sink.
 
 ### Building just the artifacts, without running tests, CheckStyle, etc.
 

--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -155,6 +155,11 @@
             </dependency>
             <dependency>
                 <groupId>io.debezium</groupId>
+                <artifactId>debezium-server-zerobus</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
                 <artifactId>debezium-server-pubsub</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -36,6 +36,7 @@
         <sink.instructlab.scope>compile</sink.instructlab.scope>
         <sink.fluss.scope>compile</sink.fluss.scope>
         <sink.jdbc.scope>compile</sink.jdbc.scope>
+        <sink.zerobus.scope>compile</sink.zerobus.scope>
     </properties>
 
     <dependencies>
@@ -146,6 +147,11 @@
             <artifactId>debezium-server-jdbc</artifactId>
             <scope>${sink.jdbc.scope}</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-server-zerobus</artifactId>
+            <scope>${sink.zerobus.scope}</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -196,6 +202,7 @@
                 <sink.instructlab.scope>test</sink.instructlab.scope>
                 <sink.fluss.scope>test</sink.fluss.scope>
                 <sink.jdbc.scope>test</sink.jdbc.scope>
+                <sink.zerobus.scope>test</sink.zerobus.scope>
             </properties>
         </profile>
 
@@ -337,6 +344,13 @@
             <id>sink-jdbc</id>
             <properties>
                 <sink.jdbc.scope>compile</sink.jdbc.scope>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>sink-zerobus</id>
+            <properties>
+                <sink.zerobus.scope>compile</sink.zerobus.scope>
             </properties>
         </profile>
 

--- a/debezium-server-zerobus/README.md
+++ b/debezium-server-zerobus/README.md
@@ -1,0 +1,127 @@
+# Debezium Server ZeroBus Sink
+
+The ZeroBus sink is a native Debezium Server sink selected with:
+
+```properties
+debezium.sink.type=zerobus
+```
+
+The native sink path is:
+
+```text
+Debezium Server -> debezium-server-zerobus -> ZeroBus native ingest -> Unity Catalog table
+```
+
+This module intentionally does not run the Kafka Connect worker/runtime, Kafka brokers, Kafka producer
+APIs, or Kafka Connect SMTs. It may inspect Debezium's embedded `SourceRecord` data model when needed,
+as other Debezium Server table-oriented sinks do.
+
+The first native implementation uses the Databricks ZeroBus Java SDK with JSON, protobuf, and Arrow
+streams. Each Debezium batch is serialized in the configured format, written with the SDK offset
+API, and acknowledged with `waitForOffset(...)` before Debezium source offsets are committed.
+
+The review packet for the first upstream contribution is
+`debezium-server-zerobus/UPSTREAM_CONTRIBUTION_PACKET.md`.
+
+## Configuration
+
+```properties
+debezium.sink.zerobus.endpoint=https://zerobus.example
+debezium.sink.zerobus.workspace.url=https://dbc-a1b2c3d4-e5f6.cloud.databricks.com
+debezium.sink.zerobus.authentication.type=oauth2
+debezium.sink.zerobus.authentication.oauth2.client-id=${ZEROBUS_CLIENT_ID}
+debezium.sink.zerobus.authentication.oauth2.client-secret=${ZEROBUS_CLIENT_SECRET}
+debezium.sink.zerobus.record.format=json
+debezium.sink.zerobus.max.inflight.batches=1000
+debezium.sink.zerobus.idempotency.mode=source
+debezium.sink.zerobus.tombstone.handling.mode=event
+debezium.sink.zerobus.table.mapping.mode=source
+debezium.sink.zerobus.table.mapping.default.catalog=main
+debezium.sink.zerobus.table.mapping.default.schema=bronze
+```
+
+`workspace.url` is the Databricks workspace URL used by the SDK as the Unity Catalog endpoint.
+The OAuth client id and secret should come from a Databricks service principal with `USE CATALOG`,
+`USE SCHEMA`, `SELECT`, and `MODIFY` on the target table.
+
+`record.format` supports `json`, `protobuf`, and `arrow`. All formats use the same stable ZeroBus envelope:
+`target_table`, `destination`, `partition`, `operation`, `idempotency_key`, `key`, `value`,
+`source_position`, and `headers`.
+
+In JSON mode, Debezium JSON strings are embedded as JSON objects rather than double-quoted text. In
+protobuf mode, the sink creates a `DebeziumZeroBusRecord` descriptor and writes the same envelope
+through `ZerobusProtoStream`; key/value/maps are encoded as canonical JSON strings inside the
+protobuf envelope. In Arrow mode, the sink creates the same envelope as an Arrow `Schema`, writes a
+`VectorSchemaRoot` through `ZerobusArrowStream`, and keeps key/value/maps as canonical JSON strings
+in nullable UTF-8 columns. Table-specific typed protobuf or source-table-shaped Arrow rows remain a
+future schema-evolution track.
+
+`max.inflight.batches` configures the ZeroBus SDK Arrow stream's in-flight batch limit. It is
+separate from `max.inflight.records`, which applies to JSON/protobuf SDK streams.
+
+`operation` is inferred from Debezium's envelope `op` code when available: `c`, `r`, `u`, and `d`
+become `create`, `read`, `update`, and `delete`. Null-value Debezium tombstone records are distinct
+from delete events and are emitted as `operation=tombstone` unless `tombstone.handling.mode=drop`.
+
+`idempotency.mode=source` writes a deterministic envelope-level `idempotency_key` from Debezium's destination,
+partition, key, and the underlying `SourceRecord` source partition/offset when available. This keeps
+LSN/transaction ordering metadata with the ZeroBus row. Header fingerprints are used only as a
+fallback for non-embedded events. Use `idempotency.mode=none` only when the target table or
+downstream process supplies its own dedupe contract.
+
+## Table Mapping
+
+The sink supports three routing modes:
+
+- `source`: maps the Debezium destination's last segment to
+  `<default.catalog>.<default.schema>.<table>`.
+- `explicit`: maps exact Debezium destinations with
+  `debezium.sink.zerobus.table.mapping.overrides`.
+- `regex`: applies a native regex/replacement pair to the Debezium destination.
+
+All target tables must be Unity Catalog identifiers in the form:
+
+```text
+catalog.schema.table
+```
+
+## Commit Semantics
+
+The sink maps and writes records first, waits for a durable ZeroBus acknowledgement, and only then
+marks records processed with Debezium's committer. A write failure or partial acknowledgement fails
+the batch before offsets are advanced. This keeps the first native implementation at-least-once
+until service-side idempotent append or row-level dedupe semantics are explicitly defined.
+
+The writer preserves Debezium input order across interleaved target tables while still batching
+consecutive records for the same target table. This keeps source-position ordering visible in the
+write sequence instead of regrouping a mixed-source batch by target table.
+
+## Java 25 Local Verification
+
+For local ZeroBus development, use Java 25 explicitly:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home \
+  mvn -pl debezium-server-zerobus test -DskipITs -Dquick -DskipTests=false -Dformat.skip=true
+```
+
+To verify generated Debezium Server sink metadata:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home \
+  mvn -pl debezium-server-zerobus prepare-package -DskipITs -Dquick -DskipTests=true -Dformat.skip=true
+```
+
+## Kafka-Compatible Recipe Boundary
+
+ZeroBus also supports a Kafka-compatible API path that can be useful for Kafka Connect deployments:
+
+```properties
+producer.override.bootstrap.servers=<zerobus-kafka-compatible-endpoint>
+producer.override.sasl.login.callback.handler.class=<zerobus-oauth-handler>
+transforms=<RegexRouter mapping>
+tombstones.on.delete=false
+```
+
+That recipe removes Kafka broker from the data path, but still runs Kafka Connect and still uses
+Kafka producer-compatible APIs. It is separate from this native Debezium Server sink.

--- a/debezium-server-zerobus/UPSTREAM_CONTRIBUTION_PACKET.md
+++ b/debezium-server-zerobus/UPSTREAM_CONTRIBUTION_PACKET.md
@@ -1,0 +1,294 @@
+# Debezium Server ZeroBus Sink Contribution Packet
+
+## Summary
+
+This contribution adds a native Debezium Server sink named `zerobus`.
+
+The native data path is:
+
+```text
+Debezium Server source connector
+  -> debezium.sink.type=zerobus
+  -> Databricks ZeroBus Java SDK JSON, protobuf, or Arrow stream
+  -> Unity Catalog target table
+```
+
+This is not a Kafka Connect sink and does not use a Kafka broker, Kafka producer
+client, or Kafka Connect SMTs in the sink implementation.
+
+## Scope
+
+Included:
+
+- New `debezium-server-zerobus` module.
+- CDI sink named `zerobus`.
+- Config model under `debezium.sink.zerobus.*`.
+- Databricks ZeroBus Java SDK client boundary.
+- JSON, protobuf, and Arrow envelope serialization.
+- Unity Catalog table routing.
+- Write-before-offset-commit batch behavior.
+- Source-order-preserving writes across interleaved target tables.
+- Retry handling and partial-ack failure handling.
+- Deterministic source-position idempotency key mode for retry stability and
+  LSN/transaction ordering.
+- Mocked unit tests.
+- Debezium Server distribution and BOM wiring.
+- Generated Debezium Server sink metadata.
+- User docs and a separate Kafka-compatible recipe boundary.
+
+Out of scope:
+
+- Kafka Connect runtime support for this native sink.
+- Kafka broker or Kafka producer API usage.
+- Kafka Connect SMT-based table routing.
+- Automatic Unity Catalog table creation.
+- Full schema evolution management.
+- Table-specific typed protobuf row generation.
+- Source-table-shaped Arrow row generation.
+- Live ZeroBus integration tests in default CI.
+
+## Configuration
+
+Minimal sink configuration:
+
+```properties
+debezium.sink.type=zerobus
+debezium.sink.zerobus.endpoint=https://zerobus.example
+debezium.sink.zerobus.workspace.url=https://dbc-a1b2c3d4-e5f6.cloud.databricks.com
+debezium.sink.zerobus.authentication.type=oauth2
+debezium.sink.zerobus.authentication.oauth2.client-id=${ZEROBUS_CLIENT_ID}
+debezium.sink.zerobus.authentication.oauth2.client-secret=${ZEROBUS_CLIENT_SECRET}
+debezium.sink.zerobus.record.format=json
+debezium.sink.zerobus.idempotency.mode=source
+debezium.sink.zerobus.tombstone.handling.mode=event
+debezium.sink.zerobus.table.mapping.mode=source
+debezium.sink.zerobus.table.mapping.default.catalog=main
+debezium.sink.zerobus.table.mapping.default.schema=bronze
+```
+
+Supported table mapping modes:
+
+- `source`: maps the last segment of the Debezium destination to
+  `<default.catalog>.<default.schema>.<table>`.
+- `explicit`: maps exact Debezium destinations using
+  `table.mapping.overrides`.
+- `regex`: applies a native regex and replacement to the Debezium destination.
+
+Supported tombstone handling modes:
+
+- `event`: write a ZeroBus row with `operation=tombstone` and `value=null`.
+- `drop`: skip null-value tombstones and still allow Debezium offsets to
+  advance after the rest of the batch succeeds.
+
+Real delete events remain separate from tombstones. When the Debezium envelope
+contains `op=d`, the sink emits `operation=delete`.
+
+Supported idempotency modes:
+
+- `source`: write a deterministic `idempotency_key` from Debezium destination,
+  partition, key, and the underlying `SourceRecord` source partition/offset
+  when available. This carries connector offsets such as LSN and transaction
+  metadata into the ZeroBus row. Header fingerprints are used only as a fallback
+  for non-embedded events.
+- `none`: omit the key when the deployment has another dedupe contract.
+
+## Record Shape
+
+The first contribution implements `record.format=json`, `record.format=protobuf`, and
+`record.format=arrow`.
+
+JSON rows written to ZeroBus contain:
+
+```json
+{
+  "target_table": "main.bronze.customers",
+  "destination": "server.inventory.customers",
+  "partition": 0,
+  "operation": "update",
+  "idempotency_key": "server.inventory.customers|partition=0|key=1|source_position=offset.event_serial_no=3&offset.lsn=123456789&offset.txId=42&partition.server=inventory",
+  "key": {},
+  "value": {},
+  "source_position": {
+    "partition.server": "inventory",
+    "offset.lsn": "123456789",
+    "offset.txId": "42",
+    "offset.event_serial_no": "3"
+  },
+  "headers": {}
+}
+```
+
+When Debezium key or value payloads are already JSON strings, the serializer
+embeds them as JSON objects instead of double-quoted text. Non-JSON strings are
+preserved as text values.
+
+Protobuf rows use the SDK's `ZerobusProtoStream` with a stable
+`DebeziumZeroBusRecord` descriptor:
+
+```protobuf
+message DebeziumZeroBusRecord {
+  string target_table = 1;
+  string destination = 2;
+  int32 partition = 3;
+  string operation = 4;
+  string idempotency_key = 5;
+  string key = 6;
+  string value = 7;
+  string source_position = 8;
+  string headers = 9;
+}
+```
+
+In protobuf mode, `key`, `value`, `source_position`, and `headers` are canonical
+JSON strings inside the envelope. Table-specific typed protobuf rows are parked
+as a schema-evolution follow-up.
+
+Arrow rows use the SDK's `ZerobusArrowStream` with the same stable envelope:
+
+```text
+target_table: Utf8
+destination: Utf8
+partition: Int(32, signed)
+operation: Utf8
+idempotency_key: Utf8
+key: Utf8
+value: Utf8
+source_position: Utf8
+headers: Utf8
+```
+
+In Arrow mode, `key`, `value`, `source_position`, and `headers` are canonical
+JSON strings in nullable UTF-8 columns. Source-table-shaped Arrow rows are parked
+as a schema-evolution follow-up and are separate from the earlier embedded
+Arrow exporter project.
+
+## Offset And Ack Semantics
+
+The sink preserves Debezium's at-least-once boundary:
+
+1. Debezium Server passes a batch of `ChangeEvent<Object, Object>` records.
+2. The sink maps each event to a `ZeroBusRecord`, including the underlying
+   `SourceRecord` source partition/offset when Debezium Server exposes an
+   `EmbeddedEngineChangeEvent`.
+3. Records are mapped into target Unity Catalog table rows.
+4. The writer preserves Debezium input order across interleaved target tables
+   and batches consecutive records for the same target table.
+5. The SDK-backed client writes each chunk with `ingestRecordsOffset(...)` for
+   JSON/protobuf streams or `ingestBatch(...)` for Arrow streams.
+6. If the SDK returns an offset, the client waits with `waitForOffset(...)`.
+7. Only after all chunks are acknowledged does the consumer call
+   `committer.markProcessed(...)` for the processed records and
+   `committer.markBatchFinished()`.
+
+If a write fails, the sink does not mark records processed. If ZeroBus partially
+acknowledges a chunk, the sink fails the batch before advancing offsets.
+
+The first contribution is at-least-once. Exactly-once semantics depend on a live
+service/table dedupe contract and are not claimed by this module.
+
+## Source Files
+
+| File | Purpose |
+|---|---|
+| `ZeroBusChangeConsumer.java` | Debezium Server sink entry point and committer boundary. |
+| `ZeroBusSinkConfig.java` | Config fields, defaults, parsing, and validation. |
+| `DatabricksZeroBusClient.java` | SDK-backed client implementation. |
+| `ZeroBusSdkAdapter.java` | Thin SDK adapter boundary around JSON/protobuf/Arrow streams. |
+| `ZeroBusClient.java` | Mockable client interface. |
+| `ZeroBusBatchWriter.java` | Grouping, batching, retry, partial-ack handling. |
+| `ZeroBusRecordMapper.java` | `ChangeEvent` to native record mapping, source-position capture, and idempotency keys. |
+| `ZeroBusTableRouter.java` | Source, explicit, and regex Unity Catalog table routing. |
+| `ZeroBusJsonSerializer.java` | JSON row serialization. |
+| `ZeroBusProtobufSerializer.java` | Protobuf descriptor and envelope serialization. |
+| `ZeroBusArrowSerializer.java` | Arrow schema and batch serialization. |
+| `ZeroBusRecord.java` | Native sink record model. |
+| `ZeroBusWriteResult.java` | Ack result model. |
+| `ZeroBusRetriableException.java` | Retryable write failure signal. |
+| `META-INF/services/io.debezium.metadata.ComponentMetadataProvider` | Debezium metadata generator discovery. |
+
+## Tests
+
+Mocked tests cover:
+
+- Required config validation.
+- JSON, protobuf, and Arrow record format validation.
+- Unsupported record format rejection.
+- Unsupported idempotency mode rejection.
+- Source, explicit, and regex table routing.
+- Invalid Unity Catalog identifiers.
+- Delete event mapping from Debezium envelope `op=d`.
+- Dropped tombstone handling.
+- Retry with a stable idempotency key.
+- SourceRecord source offset/partition capture for LSN-aware idempotency.
+- Source-order preservation across interleaved target tables.
+- Same-table batching for consecutive records.
+- Partial acknowledgement failure.
+- No offset commit on write failure.
+- Marking records processed only after durable ack.
+- JSON payload embedding and non-JSON string preservation.
+- Protobuf descriptor generation and dynamic protobuf payload parsing.
+- JSON/protobuf/Arrow SDK stream selection.
+- Arrow schema generation and batch payload serialization.
+- Arrow in-flight batch configuration validation.
+- Disabled idempotency serialization.
+
+The focused module command is:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home \
+  mvn -pl debezium-server-zerobus test -DskipITs -Dquick -DskipTests=false -Dformat.skip=true
+```
+
+## Packaging And Metadata
+
+The module is wired into:
+
+- root `pom.xml`
+- `debezium-server-bom/pom.xml`
+- `debezium-server-dist/pom.xml`
+- custom distribution profile `sink-zerobus`
+
+Generated sink metadata is verified with:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home \
+  mvn -pl debezium-server-zerobus prepare-package -DskipITs -Dquick -DskipTests=true -Dformat.skip=true
+```
+
+Expected generated descriptor:
+
+```text
+target/classes/META-INF/descriptors/server-sink/io.debezium.server.zerobus.ZeroBusChangeConsumer.json
+```
+
+The descriptor must include endpoint, workspace URL, OAuth client fields, record
+format, table mapping fields, JSON/protobuf in-flight records, Arrow in-flight
+batches, idempotency mode, and tombstone handling mode.
+
+## Kafka-Compatible Recipe Boundary
+
+ZeroBus also supports a Kafka-compatible API path for deployments that still run
+Kafka Connect:
+
+```properties
+producer.override.bootstrap.servers=<zerobus-kafka-compatible-endpoint>
+producer.override.sasl.login.callback.handler.class=<zerobus-oauth-handler>
+transforms=<RegexRouter mapping>
+tombstones.on.delete=false
+```
+
+That recipe removes Kafka broker from the data path, but it still runs Kafka
+Connect and still uses Kafka producer-compatible APIs. It is documentation-only
+for this contribution and is not the native Debezium Server sink.
+
+## Follow-Up Decisions
+
+These are intentionally parked outside the first contribution:
+
+- Live ZeroBus integration-test strategy.
+- Whether upstream CI should have a disabled-by-default integration profile.
+- Table pre-creation and schema evolution policy.
+- Downstream Delta merge/delete/upsert guidance.
+- Table-specific typed protobuf row generation.
+- Source-table-shaped Arrow row generation.
+- Exact service-side dedupe guarantees beyond the emitted `idempotency_key`.

--- a/debezium-server-zerobus/pom.xml
+++ b/debezium-server-zerobus/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-server</artifactId>
+        <version>3.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>debezium-server-zerobus</artifactId>
+    <name>Debezium Server ZeroBus Sink Adapter</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <zerobus.arrow.version>17.0.0</zerobus.arrow.version>
+        <zerobus.sdk.version>1.2.0</zerobus.sdk.version>
+        <zerobus.protobuf.version>4.33.0</zerobus.protobuf.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-server-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>zerobus-ingest-sdk</artifactId>
+            <version>${zerobus.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${zerobus.protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${zerobus.arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>${zerobus.arrow.version}</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-schema-generator</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/DatabricksZeroBusClient.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/DatabricksZeroBusClient.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import com.databricks.zerobus.ArrowStreamConfigurationOptions;
+import com.databricks.zerobus.IPCCompressionType;
+import com.databricks.zerobus.NonRetriableException;
+import com.databricks.zerobus.StreamConfigurationOptions;
+import com.databricks.zerobus.ZerobusException;
+
+import io.debezium.DebeziumException;
+
+/**
+ * ZeroBus client backed by the Databricks ZeroBus Java SDK.
+ */
+public class DatabricksZeroBusClient implements ZeroBusClient {
+
+    private final ZeroBusSinkConfig config;
+    private final ZeroBusSdkAdapter sdk;
+    private final StreamConfigurationOptions streamOptions;
+    private final ArrowStreamConfigurationOptions arrowStreamOptions;
+    private final ZeroBusJsonSerializer jsonSerializer;
+    private final ZeroBusProtobufSerializer protobufSerializer;
+    private ZeroBusArrowSerializer arrowSerializer;
+    private final Map<String, ZeroBusJsonStreamAdapter> jsonStreams = new HashMap<>();
+    private final Map<String, ZeroBusProtoStreamAdapter> protobufStreams = new HashMap<>();
+    private final Map<String, ZeroBusArrowStreamAdapter> arrowStreams = new HashMap<>();
+
+    public DatabricksZeroBusClient(ZeroBusSinkConfig config) {
+        this(config, new DatabricksZeroBusSdkAdapter(config), new ZeroBusJsonSerializer(), new ZeroBusProtobufSerializer(), null);
+    }
+
+    DatabricksZeroBusClient(ZeroBusSinkConfig config, ZeroBusSdkAdapter sdk, ZeroBusJsonSerializer jsonSerializer, ZeroBusProtobufSerializer protobufSerializer, ZeroBusArrowSerializer arrowSerializer) {
+        this.config = config;
+        this.sdk = sdk;
+        this.jsonSerializer = jsonSerializer;
+        this.protobufSerializer = protobufSerializer;
+        this.arrowSerializer = arrowSerializer;
+        this.streamOptions = StreamConfigurationOptions.builder()
+                .setMaxInflightRecords(config.getMaxInflightRecords())
+                .setRecovery(true)
+                .setRecoveryRetries(config.getRetries())
+                .setServerLackOfAckTimeoutMs(toIntMillis(config.getTimeout().toMillis(), ZeroBusSinkConfig.TIMEOUT_MS.name()))
+                .setFlushTimeoutMs(toIntMillis(config.getTimeout().toMillis(), ZeroBusSinkConfig.TIMEOUT_MS.name()))
+                .build();
+        this.arrowStreamOptions = ArrowStreamConfigurationOptions.builder()
+                .setMaxInflightBatches(config.getMaxInflightBatches())
+                .setRecovery(true)
+                .setRecoveryRetries(config.getRetries())
+                .setServerLackOfAckTimeoutMs(config.getTimeout().toMillis())
+                .setFlushTimeoutMs(config.getTimeout().toMillis())
+                .setConnectionTimeoutMs(config.getTimeout().toMillis())
+                .setIpcCompression(IPCCompressionType.NONE)
+                .build();
+    }
+
+    @Override
+    public synchronized ZeroBusWriteResult write(String targetTable, List<ZeroBusRecord> records) throws Exception {
+        if (records.isEmpty()) {
+            return ZeroBusWriteResult.acknowledged(0);
+        }
+
+        try {
+            if (ZeroBusSinkConfig.RECORD_FORMAT_PROTOBUF.equals(config.getRecordFormat())) {
+                return writeProtobuf(targetTable, records);
+            }
+            if (ZeroBusSinkConfig.RECORD_FORMAT_ARROW.equals(config.getRecordFormat())) {
+                return writeArrow(targetTable, records);
+            }
+            return writeJson(targetTable, records);
+        }
+        catch (NonRetriableException e) {
+            throw new DebeziumException("Non-retriable ZeroBus write failure for table " + targetTable, e);
+        }
+        catch (ZerobusException e) {
+            throw new ZeroBusRetriableException("Retryable ZeroBus write failure for table " + targetTable, e);
+        }
+        catch (CompletionException e) {
+            throw translateCompletionException(targetTable, e);
+        }
+    }
+
+    private ZeroBusWriteResult writeJson(String targetTable, List<ZeroBusRecord> records) throws Exception {
+        ZeroBusJsonStreamAdapter stream = jsonStreamFor(targetTable);
+        List<String> payloads = new ArrayList<>(records.size());
+        for (ZeroBusRecord record : records) {
+            payloads.add(jsonSerializer.serialize(record));
+        }
+
+        Optional<Long> offset = stream.ingestRecordsOffset(payloads);
+        if (offset.isPresent()) {
+            stream.waitForOffset(offset.get());
+        }
+        return ZeroBusWriteResult.acknowledged(records.size());
+    }
+
+    private ZeroBusWriteResult writeArrow(String targetTable, List<ZeroBusRecord> records) throws Exception {
+        ZeroBusArrowStreamAdapter stream = arrowStreamFor(targetTable);
+        try (VectorSchemaRoot root = arrowSerializer().serialize(records)) {
+            Optional<Long> offset = stream.ingestBatch(root);
+            if (offset.isPresent()) {
+                stream.waitForOffset(offset.get());
+            }
+        }
+        return ZeroBusWriteResult.acknowledged(records.size());
+    }
+
+    private ZeroBusWriteResult writeProtobuf(String targetTable, List<ZeroBusRecord> records) throws Exception {
+        ZeroBusProtoStreamAdapter stream = protobufStreamFor(targetTable);
+        List<byte[]> payloads = new ArrayList<>(records.size());
+        for (ZeroBusRecord record : records) {
+            payloads.add(protobufSerializer.serialize(record));
+        }
+
+        Optional<Long> offset = stream.ingestRecordsOffset(payloads);
+        if (offset.isPresent()) {
+            stream.waitForOffset(offset.get());
+        }
+        return ZeroBusWriteResult.acknowledged(records.size());
+    }
+
+    private ZeroBusJsonStreamAdapter jsonStreamFor(String targetTable) throws Exception {
+        ZeroBusJsonStreamAdapter existing = jsonStreams.get(targetTable);
+        if (existing != null && !existing.isClosed()) {
+            return existing;
+        }
+
+        try {
+            ZeroBusJsonStreamAdapter stream = sdk.createJsonStream(
+                    targetTable,
+                    config.getOauth2ClientId(),
+                    config.getOauth2ClientSecret(),
+                    streamOptions).get(config.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            jsonStreams.put(targetTable, stream);
+            return stream;
+        }
+        catch (CompletionException e) {
+            throw translateCompletionException(targetTable, e);
+        }
+        catch (ExecutionException e) {
+            throw translateThrowable(targetTable, e.getCause() == null ? e : e.getCause());
+        }
+        catch (TimeoutException e) {
+            throw new ZeroBusRetriableException("Timed out creating ZeroBus stream for table " + targetTable, e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+    }
+
+    private ZeroBusProtoStreamAdapter protobufStreamFor(String targetTable) throws Exception {
+        ZeroBusProtoStreamAdapter existing = protobufStreams.get(targetTable);
+        if (existing != null && !existing.isClosed()) {
+            return existing;
+        }
+
+        try {
+            ZeroBusProtoStreamAdapter stream = sdk.createProtoStream(
+                    targetTable,
+                    protobufSerializer.descriptorProto(),
+                    config.getOauth2ClientId(),
+                    config.getOauth2ClientSecret(),
+                    streamOptions).get(config.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            protobufStreams.put(targetTable, stream);
+            return stream;
+        }
+        catch (CompletionException e) {
+            throw translateCompletionException(targetTable, e);
+        }
+        catch (ExecutionException e) {
+            throw translateThrowable(targetTable, e.getCause() == null ? e : e.getCause());
+        }
+        catch (TimeoutException e) {
+            throw new ZeroBusRetriableException("Timed out creating ZeroBus stream for table " + targetTable, e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+    }
+
+    private ZeroBusArrowStreamAdapter arrowStreamFor(String targetTable) throws Exception {
+        ZeroBusArrowStreamAdapter existing = arrowStreams.get(targetTable);
+        if (existing != null && !existing.isClosed()) {
+            return existing;
+        }
+
+        try {
+            ZeroBusArrowStreamAdapter stream = sdk.createArrowStream(
+                    targetTable,
+                    arrowSerializer().schema(),
+                    config.getOauth2ClientId(),
+                    config.getOauth2ClientSecret(),
+                    arrowStreamOptions).get(config.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            arrowStreams.put(targetTable, stream);
+            return stream;
+        }
+        catch (CompletionException e) {
+            throw translateCompletionException(targetTable, e);
+        }
+        catch (ExecutionException e) {
+            throw translateThrowable(targetTable, e.getCause() == null ? e : e.getCause());
+        }
+        catch (TimeoutException e) {
+            throw new ZeroBusRetriableException("Timed out creating ZeroBus stream for table " + targetTable, e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+    }
+
+    private Exception translateCompletionException(String targetTable, CompletionException e) {
+        Throwable cause = e.getCause() == null ? e : e.getCause();
+        return translateThrowable(targetTable, cause);
+    }
+
+    private Exception translateThrowable(String targetTable, Throwable cause) {
+        if (cause instanceof NonRetriableException) {
+            return new DebeziumException("Non-retriable ZeroBus stream failure for table " + targetTable, cause);
+        }
+        if (cause instanceof ZerobusException) {
+            return new ZeroBusRetriableException("Retryable ZeroBus stream failure for table " + targetTable, cause);
+        }
+        return new DebeziumException("Failed to create ZeroBus stream for table " + targetTable, cause);
+    }
+
+    private static int toIntMillis(long millis, String fieldName) {
+        if (millis > Integer.MAX_VALUE) {
+            throw new DebeziumException("ZeroBus " + fieldName + " must not exceed " + Integer.MAX_VALUE);
+        }
+        return (int) millis;
+    }
+
+    private ZeroBusArrowSerializer arrowSerializer() {
+        if (arrowSerializer == null) {
+            arrowSerializer = new ZeroBusArrowSerializer();
+        }
+        return arrowSerializer;
+    }
+
+    @Override
+    public synchronized void close() throws Exception {
+        Exception failure = null;
+        for (ZeroBusJsonStreamAdapter stream : jsonStreams.values()) {
+            try {
+                stream.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        for (ZeroBusProtoStreamAdapter stream : protobufStreams.values()) {
+            try {
+                stream.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        for (ZeroBusArrowStreamAdapter stream : arrowStreams.values()) {
+            try {
+                stream.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        jsonStreams.clear();
+        protobufStreams.clear();
+        arrowStreams.clear();
+        try {
+            sdk.close();
+        }
+        catch (Exception e) {
+            if (failure == null) {
+                failure = e;
+            }
+        }
+        if (arrowSerializer != null) {
+            try {
+                arrowSerializer.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusArrowSerializer.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusArrowSerializer.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.Text;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Serializes mapped Debezium change events into the Arrow envelope sent to ZeroBus.
+ */
+public class ZeroBusArrowSerializer implements AutoCloseable {
+
+    private static final String TARGET_TABLE = "target_table";
+    private static final String DESTINATION = "destination";
+    private static final String PARTITION = "partition";
+    private static final String OPERATION = "operation";
+    private static final String IDEMPOTENCY_KEY = "idempotency_key";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    private static final String SOURCE_POSITION = "source_position";
+    private static final String HEADERS = "headers";
+
+    private static final Schema SCHEMA = new Schema(List.of(
+            stringField(TARGET_TABLE),
+            stringField(DESTINATION),
+            new Field(PARTITION, FieldType.nullable(new ArrowType.Int(32, true)), null),
+            stringField(OPERATION),
+            stringField(IDEMPOTENCY_KEY),
+            stringField(KEY),
+            stringField(VALUE),
+            stringField(SOURCE_POSITION),
+            stringField(HEADERS)));
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final BufferAllocator allocator;
+    private final boolean closeAllocator;
+
+    public ZeroBusArrowSerializer() {
+        this(new RootAllocator(), true);
+    }
+
+    ZeroBusArrowSerializer(BufferAllocator allocator) {
+        this(allocator, false);
+    }
+
+    private ZeroBusArrowSerializer(BufferAllocator allocator, boolean closeAllocator) {
+        this.allocator = allocator;
+        this.closeAllocator = closeAllocator;
+    }
+
+    public Schema schema() {
+        return SCHEMA;
+    }
+
+    public VectorSchemaRoot serialize(List<ZeroBusRecord> records) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(SCHEMA, allocator);
+        boolean success = false;
+        try {
+            root.allocateNew();
+
+            VarCharVector targetTable = (VarCharVector) root.getVector(TARGET_TABLE);
+            VarCharVector destination = (VarCharVector) root.getVector(DESTINATION);
+            IntVector partition = (IntVector) root.getVector(PARTITION);
+            VarCharVector operation = (VarCharVector) root.getVector(OPERATION);
+            VarCharVector idempotencyKey = (VarCharVector) root.getVector(IDEMPOTENCY_KEY);
+            VarCharVector key = (VarCharVector) root.getVector(KEY);
+            VarCharVector value = (VarCharVector) root.getVector(VALUE);
+            VarCharVector sourcePosition = (VarCharVector) root.getVector(SOURCE_POSITION);
+            VarCharVector headers = (VarCharVector) root.getVector(HEADERS);
+
+            for (int row = 0; row < records.size(); row++) {
+                ZeroBusRecord record = records.get(row);
+                set(targetTable, row, record.targetTable());
+                set(destination, row, record.destination());
+                if (record.partition() == null) {
+                    partition.setNull(row);
+                }
+                else {
+                    partition.setSafe(row, record.partition());
+                }
+                set(operation, row, record.operation().name().toLowerCase(Locale.ROOT));
+                set(idempotencyKey, row, record.idempotencyKey());
+                set(key, row, valueAsText(record.key()));
+                set(value, row, valueAsText(record.value()));
+                set(sourcePosition, row, mapAsJson(record.sourcePosition()));
+                set(headers, row, mapAsJson(record.headers()));
+            }
+
+            root.setRowCount(records.size());
+            success = true;
+            return root;
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to serialize ZeroBus Arrow record", e);
+        }
+        finally {
+            if (!success) {
+                root.close();
+            }
+        }
+    }
+
+    private static Field stringField(String name) {
+        return new Field(name, FieldType.nullable(new ArrowType.Utf8()), null);
+    }
+
+    private static void set(VarCharVector vector, int row, String value) {
+        if (value == null) {
+            vector.setNull(row);
+        }
+        else {
+            vector.setSafe(row, new Text(value));
+        }
+    }
+
+    private String valueAsText(Object value) throws IOException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof byte[] bytes) {
+            return stringAsCanonicalJsonOrText(new String(bytes, StandardCharsets.UTF_8));
+        }
+        if (value instanceof String string) {
+            return stringAsCanonicalJsonOrText(string);
+        }
+        return mapper.writeValueAsString(value);
+    }
+
+    private String mapAsJson(Map<String, String> value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return mapper.writeValueAsString(value);
+    }
+
+    private String stringAsCanonicalJsonOrText(String value) throws IOException {
+        try {
+            JsonNode json = mapper.readTree(value);
+            return mapper.writeValueAsString(json);
+        }
+        catch (IOException ignored) {
+            return value;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closeAllocator) {
+            allocator.close();
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusBatchWriter.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusBatchWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+
+public class ZeroBusBatchWriter {
+
+    private final ZeroBusSinkConfig config;
+    private final ZeroBusClient client;
+    private final ZeroBusRecordMapper mapper;
+
+    public ZeroBusBatchWriter(ZeroBusSinkConfig config, ZeroBusClient client, ZeroBusRecordMapper mapper) {
+        this.config = config;
+        this.client = client;
+        this.mapper = mapper;
+    }
+
+    public List<ChangeEvent<Object, Object>> write(List<ChangeEvent<Object, Object>> records) throws InterruptedException {
+        List<ChangeEvent<Object, Object>> processedRecords = new ArrayList<>();
+        List<ZeroBusRecord> chunk = new ArrayList<>(config.getBatchSize());
+        String currentTargetTable = null;
+
+        for (ChangeEvent<Object, Object> record : records) {
+            if (record.value() == null && ZeroBusSinkConfig.TOMBSTONE_HANDLING_DROP.equals(config.getTombstoneHandlingMode())) {
+                processedRecords.add(record);
+                continue;
+            }
+
+            ZeroBusRecord zeroBusRecord = mapper.map(record);
+            if (currentTargetTable != null
+                    && (!currentTargetTable.equals(zeroBusRecord.targetTable()) || chunk.size() >= config.getBatchSize())) {
+                writeChunk(currentTargetTable, chunk);
+                chunk.clear();
+            }
+            currentTargetTable = zeroBusRecord.targetTable();
+            chunk.add(zeroBusRecord);
+            processedRecords.add(record);
+        }
+
+        if (!chunk.isEmpty()) {
+            writeChunk(currentTargetTable, chunk);
+        }
+        return processedRecords;
+    }
+
+    private void writeChunk(String targetTable, List<ZeroBusRecord> chunk) throws InterruptedException {
+        int attempts = 0;
+        while (true) {
+            attempts++;
+            try {
+                ZeroBusWriteResult result = client.write(targetTable, chunk);
+                if (!result.allAcknowledged(chunk.size())) {
+                    throw new DebeziumException("ZeroBus partially acknowledged " + result.acknowledged().size()
+                            + " result(s) for " + chunk.size() + " record(s) written to " + targetTable);
+                }
+                return;
+            }
+            catch (ZeroBusRetriableException e) {
+                if (attempts >= config.getRetries()) {
+                    throw new DebeziumException("Exceeded maximum number of attempts to write records to ZeroBus table " + targetTable, e);
+                }
+                Metronome.sleeper(config.getRetryInterval(), Clock.SYSTEM).pause();
+            }
+            catch (DebeziumException e) {
+                throw e;
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            }
+            catch (Exception e) {
+                throw new DebeziumException("Failed to write records to ZeroBus table " + targetTable, e);
+            }
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusChangeConsumer.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusChangeConsumer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.Module;
+import io.debezium.annotation.VisibleForTesting;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.metadata.ComponentMetadata;
+import io.debezium.metadata.ComponentMetadataFactory;
+import io.debezium.server.BaseChangeConsumer;
+import io.debezium.server.ConnectionValidationResult;
+import io.debezium.server.CustomConsumerBuilder;
+import io.debezium.server.api.DebeziumServerSink;
+
+/**
+ * Native Debezium Server sink that maps change events to ZeroBus request records.
+ */
+@Named("zerobus")
+@Dependent
+public class ZeroBusChangeConsumer extends BaseChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEvent<Object, Object>>, DebeziumServerSink {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZeroBusChangeConsumer.class);
+    private static final String PROP_PREFIX = "debezium.sink.zerobus.";
+
+    private final ComponentMetadataFactory componentMetadataFactory = new ComponentMetadataFactory();
+
+    private ZeroBusClient client;
+    private ZeroBusBatchWriter writer;
+    private ZeroBusSinkConfig config;
+
+    @Inject
+    @CustomConsumerBuilder
+    Instance<ZeroBusClient> customClient;
+
+    @PostConstruct
+    void connect() {
+        initWithConfig(ConfigProvider.getConfig(), null);
+    }
+
+    @VisibleForTesting
+    void initWithConfig(Config mpConfig, ZeroBusClient clientOverride) {
+        Configuration configuration = Configuration.from(getConfigSubset(mpConfig, PROP_PREFIX));
+        config = new ZeroBusSinkConfig(configuration);
+        config.validate();
+
+        client = clientOverride != null ? clientOverride : resolveClient();
+        ZeroBusTableRouter router = new ZeroBusTableRouter(config);
+        ZeroBusRecordMapper mapper = new ZeroBusRecordMapper(router, config);
+        writer = new ZeroBusBatchWriter(config, client, mapper);
+
+        LOGGER.info("ZeroBus sink configured for endpoint '{}' with table mapping mode '{}'",
+                config.getEndpoint(), config.getTableMappingMode());
+    }
+
+    private ZeroBusClient resolveClient() {
+        if (customClient != null && customClient.isResolvable()) {
+            return customClient.get();
+        }
+        return new DatabricksZeroBusClient(config);
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        if (client != null) {
+            try {
+                client.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Exception while closing ZeroBus client", e);
+            }
+        }
+    }
+
+    @Override
+    public void handleBatch(List<ChangeEvent<Object, Object>> records,
+                            DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer)
+            throws InterruptedException {
+        if (records.isEmpty()) {
+            committer.markBatchFinished();
+            return;
+        }
+
+        List<ChangeEvent<Object, Object>> processedRecords = writer.write(records);
+        for (ChangeEvent<Object, Object> record : processedRecords) {
+            committer.markProcessed(record);
+        }
+        committer.markBatchFinished();
+    }
+
+    @Override
+    public ConnectionValidationResult validateConnection(Map<String, Object> config) {
+        try {
+            ZeroBusSinkConfig sinkConfig = new ZeroBusSinkConfig(Configuration.from(config));
+            sinkConfig.validate();
+            return ConnectionValidationResult.successful();
+        }
+        catch (Exception e) {
+            return ConnectionValidationResult.failed(e.getMessage());
+        }
+    }
+
+    @Override
+    public Field.Set getConfigFields() {
+        return Field.setOf(
+                ZeroBusSinkConfig.ENDPOINT,
+                ZeroBusSinkConfig.WORKSPACE_URL,
+                ZeroBusSinkConfig.AUTHENTICATION_TYPE,
+                ZeroBusSinkConfig.OAUTH2_CLIENT_ID,
+                ZeroBusSinkConfig.OAUTH2_CLIENT_SECRET,
+                ZeroBusSinkConfig.RECORD_FORMAT,
+                ZeroBusSinkConfig.TABLE_MAPPING_MODE,
+                ZeroBusSinkConfig.TABLE_MAPPING_DEFAULT_CATALOG,
+                ZeroBusSinkConfig.TABLE_MAPPING_DEFAULT_SCHEMA,
+                ZeroBusSinkConfig.TABLE_MAPPING_OVERRIDES,
+                ZeroBusSinkConfig.TABLE_MAPPING_REGEX,
+                ZeroBusSinkConfig.TABLE_MAPPING_REPLACEMENT,
+                ZeroBusSinkConfig.BATCH_SIZE,
+                ZeroBusSinkConfig.RETRIES,
+                ZeroBusSinkConfig.RETRY_INTERVAL_MS,
+                ZeroBusSinkConfig.TIMEOUT_MS,
+                ZeroBusSinkConfig.MAX_INFLIGHT_RECORDS,
+                ZeroBusSinkConfig.MAX_INFLIGHT_BATCHES,
+                ZeroBusSinkConfig.IDEMPOTENCY_MODE,
+                ZeroBusSinkConfig.TOMBSTONE_HANDLING_MODE);
+    }
+
+    @Override
+    public List<ComponentMetadata> getConnectorMetadata() {
+        return List.of(componentMetadataFactory.createComponentMetadata(this, Module.version()));
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusClient.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusClient.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.List;
+
+public interface ZeroBusClient extends AutoCloseable {
+
+    ZeroBusWriteResult write(String targetTable, List<ZeroBusRecord> records) throws Exception;
+
+    @Override
+    default void close() throws Exception {
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusJsonSerializer.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusJsonSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Serializes mapped Debezium change events into the JSON rows sent to ZeroBus.
+ */
+public class ZeroBusJsonSerializer {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public String serialize(ZeroBusRecord record) {
+        ObjectNode root = mapper.createObjectNode();
+        root.put("target_table", record.targetTable());
+        root.put("destination", record.destination());
+        root.put("partition", record.partition());
+        root.put("operation", record.operation().name().toLowerCase(Locale.ROOT));
+        root.put("idempotency_key", record.idempotencyKey());
+        root.set("key", toJsonNode(record.key()));
+        root.set("value", toJsonNode(record.value()));
+        root.set("source_position", mapper.valueToTree(record.sourcePosition()));
+        root.set("headers", mapper.valueToTree(record.headers()));
+
+        try {
+            return mapper.writeValueAsString(root);
+        }
+        catch (JsonProcessingException e) {
+            throw new DebeziumException("Failed to serialize ZeroBus record", e);
+        }
+    }
+
+    private JsonNode toJsonNode(Object value) {
+        if (value == null) {
+            return NullNode.getInstance();
+        }
+        if (value instanceof byte[] bytes) {
+            return stringToJsonNode(new String(bytes, StandardCharsets.UTF_8));
+        }
+        if (value instanceof String string) {
+            return stringToJsonNode(string);
+        }
+        return mapper.valueToTree(value);
+    }
+
+    private JsonNode stringToJsonNode(String value) {
+        try {
+            return mapper.readTree(value);
+        }
+        catch (IOException ignored) {
+            return mapper.getNodeFactory().textNode(value);
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusOperation.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.Locale;
+
+public enum ZeroBusOperation {
+    CREATE,
+    READ,
+    UPDATE,
+    CHANGE,
+    DELETE,
+    TOMBSTONE;
+
+    public static ZeroBusOperation fromDebeziumCode(String code) {
+        if (code == null || code.isBlank()) {
+            return CHANGE;
+        }
+        return switch (code.toLowerCase(Locale.ROOT)) {
+            case "c" -> CREATE;
+            case "r" -> READ;
+            case "u" -> UPDATE;
+            case "d" -> DELETE;
+            default -> CHANGE;
+        };
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusProtobufSerializer.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusProtobufSerializer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Serializes mapped Debezium change events into the protobuf envelope sent to ZeroBus.
+ */
+public class ZeroBusProtobufSerializer {
+
+    private static final String MESSAGE_NAME = "DebeziumZeroBusRecord";
+    private static final DescriptorProto DESCRIPTOR_PROTO = DescriptorProto.newBuilder()
+            .setName(MESSAGE_NAME)
+            .addField(field("target_table", 1, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("destination", 2, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("partition", 3, FieldDescriptorProto.Type.TYPE_INT32))
+            .addField(field("operation", 4, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("idempotency_key", 5, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("key", 6, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("value", 7, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("source_position", 8, FieldDescriptorProto.Type.TYPE_STRING))
+            .addField(field("headers", 9, FieldDescriptorProto.Type.TYPE_STRING))
+            .build();
+
+    private static final Descriptors.Descriptor DESCRIPTOR = descriptor(DESCRIPTOR_PROTO);
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public DescriptorProto descriptorProto() {
+        return DESCRIPTOR_PROTO;
+    }
+
+    public Descriptors.Descriptor descriptor() {
+        return DESCRIPTOR;
+    }
+
+    public byte[] serialize(ZeroBusRecord record) {
+        try {
+            DynamicMessage.Builder builder = DynamicMessage.newBuilder(DESCRIPTOR);
+            set(builder, "target_table", record.targetTable());
+            set(builder, "destination", record.destination());
+            if (record.partition() != null) {
+                builder.setField(DESCRIPTOR.findFieldByName("partition"), record.partition());
+            }
+            set(builder, "operation", record.operation().name().toLowerCase(Locale.ROOT));
+            set(builder, "idempotency_key", record.idempotencyKey());
+            set(builder, "key", valueAsText(record.key()));
+            set(builder, "value", valueAsText(record.value()));
+            set(builder, "source_position", mapAsJson(record.sourcePosition()));
+            set(builder, "headers", mapAsJson(record.headers()));
+            return builder.build().toByteArray();
+        }
+        catch (IOException e) {
+            throw new DebeziumException("Failed to serialize ZeroBus protobuf record", e);
+        }
+    }
+
+    private static FieldDescriptorProto field(String name, int number, FieldDescriptorProto.Type type) {
+        return FieldDescriptorProto.newBuilder()
+                .setName(name)
+                .setNumber(number)
+                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                .setType(type)
+                .build();
+    }
+
+    private static Descriptors.Descriptor descriptor(DescriptorProto descriptorProto) {
+        try {
+            FileDescriptorProto fileDescriptorProto = FileDescriptorProto.newBuilder()
+                    .setName("debezium_zerobus_record.proto")
+                    .setSyntax("proto3")
+                    .addMessageType(descriptorProto)
+                    .build();
+            return Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, new Descriptors.FileDescriptor[0])
+                    .findMessageTypeByName(MESSAGE_NAME);
+        }
+        catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static void set(DynamicMessage.Builder builder, String fieldName, String value) {
+        if (value != null) {
+            builder.setField(DESCRIPTOR.findFieldByName(fieldName), value);
+        }
+    }
+
+    private String valueAsText(Object value) throws IOException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof byte[] bytes) {
+            return stringAsCanonicalJsonOrText(new String(bytes, StandardCharsets.UTF_8));
+        }
+        if (value instanceof String string) {
+            return stringAsCanonicalJsonOrText(string);
+        }
+        return mapper.writeValueAsString(value);
+    }
+
+    private String mapAsJson(Map<String, String> value) throws IOException {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return mapper.writeValueAsString(value);
+    }
+
+    private String stringAsCanonicalJsonOrText(String value) throws IOException {
+        try {
+            JsonNode json = mapper.readTree(value);
+            return mapper.writeValueAsString(json);
+        }
+        catch (IOException ignored) {
+            return value;
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRecord.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRecord.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.Map;
+
+public record ZeroBusRecord(
+        String targetTable,
+        String destination,
+        Integer partition,
+        Object key,
+        Object value,
+        Map<String, String> sourcePosition,
+        Map<String, String> headers,
+        ZeroBusOperation operation,
+        String idempotencyKey) {
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRecordMapper.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRecordMapper.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.data.Envelope;
+import io.debezium.embedded.EmbeddedEngineChangeEvent;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.Header;
+import io.debezium.server.BaseChangeConsumer;
+
+/**
+ * Converts Debezium change events into the native request shape expected by the ZeroBus client boundary.
+ */
+public class ZeroBusRecordMapper extends BaseChangeConsumer {
+
+    private final ZeroBusTableRouter tableRouter;
+    private final ZeroBusSinkConfig config;
+    private final ObjectMapper jsonMapper = new ObjectMapper();
+
+    public ZeroBusRecordMapper(ZeroBusTableRouter tableRouter, ZeroBusSinkConfig config) {
+        this.tableRouter = tableRouter;
+        this.config = config;
+    }
+
+    public ZeroBusRecord map(ChangeEvent<Object, Object> record) {
+        List<Header<Object>> eventHeaders = record.headers();
+        Map<String, String> sourcePosition = sourcePosition(record);
+        Map<String, String> headers = convertHeaders(record).entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (left, right) -> right,
+                        LinkedHashMap::new));
+
+        ZeroBusOperation operation = operation(record);
+        return new ZeroBusRecord(
+                tableRouter.route(record),
+                record.destination(),
+                record.partition(),
+                record.key(),
+                record.value(),
+                sourcePosition,
+                Map.copyOf(headers),
+                operation,
+                idempotencyKey(record, sourcePosition, eventHeaders));
+    }
+
+    private ZeroBusOperation operation(ChangeEvent<Object, Object> record) {
+        if (record.value() == null) {
+            return ZeroBusOperation.TOMBSTONE;
+        }
+        return ZeroBusOperation.fromDebeziumCode(debeziumOperationCode(record));
+    }
+
+    private String debeziumOperationCode(ChangeEvent<Object, Object> record) {
+        String sourceRecordOperation = sourceRecordOperation(record);
+        if (sourceRecordOperation != null) {
+            return sourceRecordOperation;
+        }
+        return jsonOperation(record.value());
+    }
+
+    private String sourceRecordOperation(ChangeEvent<Object, Object> record) {
+        SourceRecord sourceRecord = sourceRecord(record);
+        if (sourceRecord == null || sourceRecord.value() == null || sourceRecord.valueSchema() == null) {
+            return null;
+        }
+        if (Envelope.isEnvelopeSchema(sourceRecord.valueSchema()) && sourceRecord.value() instanceof Struct valueStruct) {
+            return valueStruct.getString(Envelope.FieldName.OPERATION);
+        }
+        return null;
+    }
+
+    private Map<String, String> sourcePosition(ChangeEvent<Object, Object> record) {
+        SourceRecord sourceRecord = sourceRecord(record);
+        if (sourceRecord == null) {
+            return Map.of();
+        }
+
+        Map<String, String> position = new LinkedHashMap<>();
+        copyPosition("partition.", sourceRecord.sourcePartition(), position);
+        copyPosition("offset.", sourceRecord.sourceOffset(), position);
+        return Map.copyOf(position);
+    }
+
+    private SourceRecord sourceRecord(ChangeEvent<Object, Object> record) {
+        if (!(record instanceof EmbeddedEngineChangeEvent<?, ?, ?> embeddedEvent)) {
+            return null;
+        }
+        return embeddedEvent.sourceRecord();
+    }
+
+    private String jsonOperation(Object value) {
+        String json = jsonString(value);
+        if (json == null) {
+            return null;
+        }
+        try {
+            JsonNode root = jsonMapper.readTree(json);
+            JsonNode op = root.get("op");
+            if (op == null || op.isNull()) {
+                op = root.path("payload").get("op");
+            }
+            return op == null || op.isNull() ? null : op.asText();
+        }
+        catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String jsonString(Object value) {
+        if (value instanceof String string) {
+            return string;
+        }
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    private void copyPosition(String prefix, Map<String, ?> source, Map<String, String> target) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        source.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> target.put(prefix + entry.getKey(), asString(entry.getValue())));
+    }
+
+    private String idempotencyKey(ChangeEvent<Object, Object> record, Map<String, String> sourcePosition, List<Header<Object>> headers) {
+        if (ZeroBusSinkConfig.IDEMPOTENCY_NONE.equals(config.getIdempotencyMode())) {
+            return null;
+        }
+        if (!sourcePosition.isEmpty()) {
+            String sourceFingerprint = sourcePosition.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .map(entry -> entry.getKey() + "=" + entry.getValue())
+                    .collect(Collectors.joining("&"));
+            return asString(record.destination())
+                    + "|partition=" + asString(record.partition())
+                    + "|key=" + asString(record.key())
+                    + "|source_position=" + sourceFingerprint;
+        }
+        String headerFingerprint = headers.stream()
+                .sorted(Comparator.comparing(Header::getKey))
+                .map(header -> header.getKey() + "=" + asString(header.getValue()))
+                .collect(Collectors.joining("&"));
+        return asString(record.destination())
+                + "|partition=" + asString(record.partition())
+                + "|key=" + asString(record.key())
+                + "|headers=" + headerFingerprint;
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRetriableException.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusRetriableException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+public class ZeroBusRetriableException extends Exception {
+
+    public ZeroBusRetriableException(String message) {
+        super(message);
+    }
+
+    public ZeroBusRetriableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusSdkAdapter.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusSdkAdapter.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import com.databricks.zerobus.ArrowStreamConfigurationOptions;
+import com.databricks.zerobus.StreamConfigurationOptions;
+import com.databricks.zerobus.ZerobusArrowStream;
+import com.databricks.zerobus.ZerobusJsonStream;
+import com.databricks.zerobus.ZerobusProtoStream;
+import com.databricks.zerobus.ZerobusSdk;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+
+interface ZeroBusSdkAdapter extends AutoCloseable {
+
+    CompletableFuture<ZeroBusJsonStreamAdapter> createJsonStream(String targetTable,
+                                                                 String clientId,
+                                                                 String clientSecret,
+                                                                 StreamConfigurationOptions options);
+
+    CompletableFuture<ZeroBusProtoStreamAdapter> createProtoStream(String targetTable,
+                                                                   DescriptorProto descriptor,
+                                                                   String clientId,
+                                                                   String clientSecret,
+                                                                   StreamConfigurationOptions options);
+
+    CompletableFuture<ZeroBusArrowStreamAdapter> createArrowStream(String targetTable,
+                                                                   Schema schema,
+                                                                   String clientId,
+                                                                   String clientSecret,
+                                                                   ArrowStreamConfigurationOptions options);
+
+    @Override
+    void close();
+}
+
+interface ZeroBusJsonStreamAdapter extends AutoCloseable {
+
+    Optional<Long> ingestRecordsOffset(List<String> records) throws Exception;
+
+    void waitForOffset(long offset) throws Exception;
+
+    boolean isClosed();
+
+    @Override
+    void close() throws Exception;
+}
+
+interface ZeroBusProtoStreamAdapter extends AutoCloseable {
+
+    Optional<Long> ingestRecordsOffset(List<byte[]> records) throws Exception;
+
+    void waitForOffset(long offset) throws Exception;
+
+    boolean isClosed();
+
+    @Override
+    void close() throws Exception;
+}
+
+interface ZeroBusArrowStreamAdapter extends AutoCloseable {
+
+    Optional<Long> ingestBatch(VectorSchemaRoot root) throws Exception;
+
+    void waitForOffset(long offset) throws Exception;
+
+    boolean isClosed();
+
+    @Override
+    void close() throws Exception;
+}
+
+final class DatabricksZeroBusSdkAdapter implements ZeroBusSdkAdapter {
+
+    private final ZerobusSdk sdk;
+
+    DatabricksZeroBusSdkAdapter(ZeroBusSinkConfig config) {
+        this.sdk = new ZerobusSdk(config.getEndpoint(), config.getWorkspaceUrl());
+    }
+
+    @Override
+    public CompletableFuture<ZeroBusJsonStreamAdapter> createJsonStream(String targetTable,
+                                                                        String clientId,
+                                                                        String clientSecret,
+                                                                        StreamConfigurationOptions options) {
+        return sdk.createJsonStream(targetTable, clientId, clientSecret, options)
+                .thenApply(DatabricksZeroBusJsonStreamAdapter::new);
+    }
+
+    @Override
+    public CompletableFuture<ZeroBusProtoStreamAdapter> createProtoStream(String targetTable,
+                                                                          DescriptorProto descriptor,
+                                                                          String clientId,
+                                                                          String clientSecret,
+                                                                          StreamConfigurationOptions options) {
+        return sdk.createProtoStream(targetTable, descriptor, clientId, clientSecret, options)
+                .thenApply(DatabricksZeroBusProtoStreamAdapter::new);
+    }
+
+    @Override
+    public CompletableFuture<ZeroBusArrowStreamAdapter> createArrowStream(String targetTable,
+                                                                          Schema schema,
+                                                                          String clientId,
+                                                                          String clientSecret,
+                                                                          ArrowStreamConfigurationOptions options) {
+        return sdk.createArrowStream(targetTable, schema, clientId, clientSecret, options)
+                .thenApply(DatabricksZeroBusArrowStreamAdapter::new);
+    }
+
+    @Override
+    public void close() {
+        sdk.close();
+    }
+}
+
+final class DatabricksZeroBusJsonStreamAdapter implements ZeroBusJsonStreamAdapter {
+
+    private final ZerobusJsonStream stream;
+
+    DatabricksZeroBusJsonStreamAdapter(ZerobusJsonStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public Optional<Long> ingestRecordsOffset(List<String> records) throws Exception {
+        return stream.ingestRecordsOffset(records);
+    }
+
+    @Override
+    public void waitForOffset(long offset) throws Exception {
+        stream.waitForOffset(offset);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return stream.isClosed();
+    }
+
+    @Override
+    public void close() throws Exception {
+        stream.close();
+    }
+}
+
+final class DatabricksZeroBusArrowStreamAdapter implements ZeroBusArrowStreamAdapter {
+
+    private final ZerobusArrowStream stream;
+
+    DatabricksZeroBusArrowStreamAdapter(ZerobusArrowStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public Optional<Long> ingestBatch(VectorSchemaRoot root) throws Exception {
+        return stream.ingestBatch(root);
+    }
+
+    @Override
+    public void waitForOffset(long offset) throws Exception {
+        stream.waitForOffset(offset);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return stream.isClosed();
+    }
+
+    @Override
+    public void close() throws Exception {
+        stream.close();
+    }
+}
+
+final class DatabricksZeroBusProtoStreamAdapter implements ZeroBusProtoStreamAdapter {
+
+    private final ZerobusProtoStream stream;
+
+    DatabricksZeroBusProtoStreamAdapter(ZerobusProtoStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public Optional<Long> ingestRecordsOffset(List<byte[]> records) throws Exception {
+        return stream.ingestRecordsOffset(records);
+    }
+
+    @Override
+    public void waitForOffset(long offset) throws Exception {
+        stream.waitForOffset(offset);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return stream.isClosed();
+    }
+
+    @Override
+    public void close() throws Exception {
+        stream.close();
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusSinkConfig.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusSinkConfig.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+
+/**
+ * Configuration fields for {@link ZeroBusChangeConsumer}.
+ */
+public class ZeroBusSinkConfig {
+
+    public static final int DEFAULT_BATCH_SIZE = 200;
+    public static final int DEFAULT_RETRIES = 5;
+    public static final int DEFAULT_MAX_INFLIGHT_RECORDS = 1_000_000;
+    public static final int DEFAULT_MAX_INFLIGHT_BATCHES = 1_000;
+
+    public static final String AUTHENTICATION_OAUTH2 = "oauth2";
+    public static final String RECORD_FORMAT_JSON = "json";
+    public static final String RECORD_FORMAT_PROTOBUF = "protobuf";
+    public static final String RECORD_FORMAT_ARROW = "arrow";
+    public static final String TABLE_MAPPING_SOURCE = "source";
+    public static final String TABLE_MAPPING_EXPLICIT = "explicit";
+    public static final String TABLE_MAPPING_REGEX_MODE = "regex";
+    public static final String IDEMPOTENCY_SOURCE = "source";
+    public static final String IDEMPOTENCY_NONE = "none";
+    public static final String TOMBSTONE_HANDLING_EVENT = "event";
+    public static final String TOMBSTONE_HANDLING_DROP = "drop";
+
+    public static final Field ENDPOINT = Field.create("endpoint")
+            .withDisplayName("ZeroBus endpoint")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("ZeroBus native ingest endpoint.");
+
+    public static final Field WORKSPACE_URL = Field.create("workspace.url")
+            .withDisplayName("Databricks workspace URL")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Databricks workspace URL used as the Unity Catalog endpoint by the ZeroBus SDK.");
+
+    public static final Field AUTHENTICATION_TYPE = Field.create("authentication.type")
+            .withDisplayName("Authentication type")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("ZeroBus authentication type. The initial supported value is 'oauth2'.");
+
+    public static final Field OAUTH2_CLIENT_ID = Field.create("authentication.oauth2.client-id")
+            .withDisplayName("OAuth2 client ID")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("OAuth2 client ID used by the ZeroBus SDK-backed client.");
+
+    public static final Field OAUTH2_CLIENT_SECRET = Field.create("authentication.oauth2.client-secret")
+            .withDisplayName("OAuth2 client secret")
+            .withType(ConfigDef.Type.PASSWORD)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("OAuth2 client secret used by the ZeroBus SDK-backed client.");
+
+    public static final Field RECORD_FORMAT = Field.create("record.format")
+            .withDisplayName("ZeroBus record format")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(RECORD_FORMAT_JSON)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("ZeroBus SDK record format. Supported values are 'json', 'protobuf', and 'arrow'.");
+
+    public static final Field TABLE_MAPPING_MODE = Field.create("table.mapping.mode")
+            .withDisplayName("Table mapping mode")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(TABLE_MAPPING_SOURCE)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Table mapping mode: 'source', 'explicit', or 'regex'.");
+
+    public static final Field TABLE_MAPPING_DEFAULT_CATALOG = Field.create("table.mapping.default.catalog")
+            .withDisplayName("Default Unity Catalog catalog")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Default Unity Catalog catalog used by source and regex table mapping modes.");
+
+    public static final Field TABLE_MAPPING_DEFAULT_SCHEMA = Field.create("table.mapping.default.schema")
+            .withDisplayName("Default Unity Catalog schema")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Default Unity Catalog schema used by source table mapping mode.");
+
+    public static final Field TABLE_MAPPING_OVERRIDES = Field.create("table.mapping.overrides")
+            .withDisplayName("Explicit table mapping overrides")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Comma-separated mappings in the form '<source-destination>=<catalog.schema.table>'.");
+
+    public static final Field TABLE_MAPPING_REGEX = Field.create("table.mapping.regex")
+            .withDisplayName("Regex table mapping pattern")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Regex applied to the Debezium event destination when table.mapping.mode=regex.");
+
+    public static final Field TABLE_MAPPING_REPLACEMENT = Field.create("table.mapping.replacement")
+            .withDisplayName("Regex table mapping replacement")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Replacement that must produce a Unity Catalog table identifier.");
+
+    public static final Field BATCH_SIZE = Field.create("batch.size")
+            .withDisplayName("Batch size")
+            .withType(ConfigDef.Type.INT)
+            .withDefault(DEFAULT_BATCH_SIZE)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Maximum number of records to write in one ZeroBus request.");
+
+    public static final Field RETRIES = Field.create("retries")
+            .withDisplayName("Max retries")
+            .withType(ConfigDef.Type.INT)
+            .withDefault(DEFAULT_RETRIES)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Maximum retry attempts for retryable ZeroBus writes.");
+
+    public static final Field RETRY_INTERVAL_MS = Field.create("retry.interval.ms")
+            .withDisplayName("Retry interval (ms)")
+            .withType(ConfigDef.Type.LONG)
+            .withDefault(1000L)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Interval in milliseconds between retryable ZeroBus write attempts.");
+
+    public static final Field TIMEOUT_MS = Field.create("timeout.ms")
+            .withDisplayName("Client timeout (ms)")
+            .withType(ConfigDef.Type.LONG)
+            .withDefault(60000L)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Timeout in milliseconds for the SDK-backed ZeroBus client.");
+
+    public static final Field MAX_INFLIGHT_RECORDS = Field.create("max.inflight.records")
+            .withDisplayName("Maximum in-flight records")
+            .withType(ConfigDef.Type.INT)
+            .withDefault(DEFAULT_MAX_INFLIGHT_RECORDS)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Maximum unacknowledged records allowed by the ZeroBus SDK stream.");
+
+    public static final Field MAX_INFLIGHT_BATCHES = Field.create("max.inflight.batches")
+            .withDisplayName("Maximum in-flight Arrow batches")
+            .withType(ConfigDef.Type.INT)
+            .withDefault(DEFAULT_MAX_INFLIGHT_BATCHES)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Maximum unacknowledged Arrow batches allowed by the ZeroBus SDK Arrow stream.");
+
+    public static final Field IDEMPOTENCY_MODE = Field.create("idempotency.mode")
+            .withDisplayName("Idempotency mode")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(IDEMPOTENCY_SOURCE)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Idempotency mode: 'source' writes a deterministic envelope-level idempotency_key from destination, partition, key, and SourceRecord source partition/offset when available; 'none' omits it.");
+
+    public static final Field TOMBSTONE_HANDLING_MODE = Field.create("tombstone.handling.mode")
+            .withDisplayName("Tombstone handling mode")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(TOMBSTONE_HANDLING_EVENT)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Null-value tombstone handling mode: 'event' writes an operation=tombstone row, 'drop' skips tombstones.");
+
+    private final String endpoint;
+    private final String workspaceUrl;
+    private final String authenticationType;
+    private final String oauth2ClientId;
+    private final String oauth2ClientSecret;
+    private final String recordFormat;
+    private final String tableMappingMode;
+    private final String tableMappingDefaultCatalog;
+    private final String tableMappingDefaultSchema;
+    private final Map<String, String> tableMappingOverrides;
+    private final String tableMappingRegex;
+    private final String tableMappingReplacement;
+    private final int batchSize;
+    private final int retries;
+    private final Duration retryInterval;
+    private final Duration timeout;
+    private final int maxInflightRecords;
+    private final int maxInflightBatches;
+    private final String idempotencyMode;
+    private final String tombstoneHandlingMode;
+
+    public ZeroBusSinkConfig(Configuration config) {
+        endpoint = trimToNull(config.getString(ENDPOINT));
+        workspaceUrl = trimToNull(config.getString(WORKSPACE_URL));
+        authenticationType = lower(config.getString(AUTHENTICATION_TYPE));
+        oauth2ClientId = trimToNull(config.getString(OAUTH2_CLIENT_ID));
+        oauth2ClientSecret = trimToNull(config.getString(OAUTH2_CLIENT_SECRET));
+        recordFormat = lower(config.getString(RECORD_FORMAT));
+        tableMappingMode = lower(config.getString(TABLE_MAPPING_MODE));
+        tableMappingDefaultCatalog = trimToNull(config.getString(TABLE_MAPPING_DEFAULT_CATALOG));
+        tableMappingDefaultSchema = trimToNull(config.getString(TABLE_MAPPING_DEFAULT_SCHEMA));
+        tableMappingOverrides = parseOverrides(config.getString(TABLE_MAPPING_OVERRIDES));
+        tableMappingRegex = trimToNull(config.getString(TABLE_MAPPING_REGEX));
+        tableMappingReplacement = trimToNull(config.getString(TABLE_MAPPING_REPLACEMENT));
+        batchSize = config.getInteger(BATCH_SIZE);
+        retries = config.getInteger(RETRIES);
+        retryInterval = Duration.ofMillis(config.getLong(RETRY_INTERVAL_MS));
+        timeout = Duration.ofMillis(config.getLong(TIMEOUT_MS));
+        maxInflightRecords = config.getInteger(MAX_INFLIGHT_RECORDS);
+        maxInflightBatches = config.getInteger(MAX_INFLIGHT_BATCHES);
+        idempotencyMode = lower(config.getString(IDEMPOTENCY_MODE));
+        tombstoneHandlingMode = lower(config.getString(TOMBSTONE_HANDLING_MODE));
+    }
+
+    public void validate() {
+        require(endpoint, ENDPOINT.name());
+        require(workspaceUrl, WORKSPACE_URL.name());
+        require(authenticationType, AUTHENTICATION_TYPE.name());
+
+        if (!AUTHENTICATION_OAUTH2.equals(authenticationType)) {
+            throw new DebeziumException("Unsupported ZeroBus authentication type '" + authenticationType + "'");
+        }
+        require(oauth2ClientId, OAUTH2_CLIENT_ID.name());
+        require(oauth2ClientSecret, OAUTH2_CLIENT_SECRET.name());
+        if (!RECORD_FORMAT_JSON.equals(recordFormat) && !RECORD_FORMAT_PROTOBUF.equals(recordFormat) && !RECORD_FORMAT_ARROW.equals(recordFormat)) {
+            throw new DebeziumException("Unsupported ZeroBus record format '" + recordFormat + "'");
+        }
+
+        if (TABLE_MAPPING_SOURCE.equals(tableMappingMode)) {
+            require(tableMappingDefaultCatalog, TABLE_MAPPING_DEFAULT_CATALOG.name());
+            require(tableMappingDefaultSchema, TABLE_MAPPING_DEFAULT_SCHEMA.name());
+        }
+        else if (TABLE_MAPPING_EXPLICIT.equals(tableMappingMode)) {
+            if (tableMappingOverrides.isEmpty()) {
+                throw new DebeziumException("ZeroBus table.mapping.overrides is required when table.mapping.mode=explicit");
+            }
+            tableMappingOverrides.values().forEach(ZeroBusTableRouter::validateUnityCatalogTable);
+        }
+        else if (TABLE_MAPPING_REGEX_MODE.equals(tableMappingMode)) {
+            require(tableMappingRegex, TABLE_MAPPING_REGEX.name());
+            require(tableMappingReplacement, TABLE_MAPPING_REPLACEMENT.name());
+            try {
+                Pattern.compile(tableMappingRegex);
+            }
+            catch (PatternSyntaxException e) {
+                throw new DebeziumException("Invalid ZeroBus table mapping regex '" + tableMappingRegex + "'", e);
+            }
+        }
+        else {
+            throw new DebeziumException("Unsupported ZeroBus table mapping mode '" + tableMappingMode + "'");
+        }
+
+        if (batchSize <= 0) {
+            throw new DebeziumException("ZeroBus batch.size must be greater than 0");
+        }
+        if (retries <= 0) {
+            throw new DebeziumException("ZeroBus retries must be greater than 0");
+        }
+        if (retryInterval.isNegative()) {
+            throw new DebeziumException("ZeroBus retry.interval.ms must not be negative");
+        }
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new DebeziumException("ZeroBus timeout.ms must be greater than 0");
+        }
+        if (maxInflightRecords <= 0) {
+            throw new DebeziumException("ZeroBus max.inflight.records must be greater than 0");
+        }
+        if (maxInflightBatches <= 0) {
+            throw new DebeziumException("ZeroBus max.inflight.batches must be greater than 0");
+        }
+        if (!IDEMPOTENCY_SOURCE.equals(idempotencyMode) && !IDEMPOTENCY_NONE.equals(idempotencyMode)) {
+            throw new DebeziumException("Unsupported ZeroBus idempotency mode '" + idempotencyMode + "'");
+        }
+        if (!TOMBSTONE_HANDLING_EVENT.equals(tombstoneHandlingMode) && !TOMBSTONE_HANDLING_DROP.equals(tombstoneHandlingMode)) {
+            throw new DebeziumException("Unsupported ZeroBus tombstone handling mode '" + tombstoneHandlingMode + "'");
+        }
+    }
+
+    private static Map<String, String> parseOverrides(String raw) {
+        Map<String, String> overrides = new LinkedHashMap<>();
+        String value = trimToNull(raw);
+        if (value == null) {
+            return overrides;
+        }
+
+        for (String mapping : value.split(",")) {
+            String entry = mapping.trim();
+            if (entry.isEmpty()) {
+                continue;
+            }
+            int separator = entry.indexOf('=');
+            if (separator <= 0 || separator == entry.length() - 1) {
+                throw new DebeziumException("Invalid ZeroBus table mapping override '" + entry + "'");
+            }
+            overrides.put(entry.substring(0, separator).trim(), entry.substring(separator + 1).trim());
+        }
+        return Map.copyOf(overrides);
+    }
+
+    private static void require(String value, String fieldName) {
+        if (value == null) {
+            throw new DebeziumException("Missing required ZeroBus configuration property '" + fieldName + "'");
+        }
+    }
+
+    private static String lower(String value) {
+        String trimmed = trimToNull(value);
+        return trimmed == null ? null : trimmed.toLowerCase(Locale.ROOT);
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getWorkspaceUrl() {
+        return workspaceUrl;
+    }
+
+    public String getAuthenticationType() {
+        return authenticationType;
+    }
+
+    public String getOauth2ClientId() {
+        return oauth2ClientId;
+    }
+
+    public String getOauth2ClientSecret() {
+        return oauth2ClientSecret;
+    }
+
+    public String getRecordFormat() {
+        return recordFormat;
+    }
+
+    public String getTableMappingMode() {
+        return tableMappingMode;
+    }
+
+    public String getTableMappingDefaultCatalog() {
+        return tableMappingDefaultCatalog;
+    }
+
+    public String getTableMappingDefaultSchema() {
+        return tableMappingDefaultSchema;
+    }
+
+    public Map<String, String> getTableMappingOverrides() {
+        return tableMappingOverrides;
+    }
+
+    public String getTableMappingRegex() {
+        return tableMappingRegex;
+    }
+
+    public String getTableMappingReplacement() {
+        return tableMappingReplacement;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public Duration getRetryInterval() {
+        return retryInterval;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public int getMaxInflightRecords() {
+        return maxInflightRecords;
+    }
+
+    public int getMaxInflightBatches() {
+        return maxInflightBatches;
+    }
+
+    public String getIdempotencyMode() {
+        return idempotencyMode;
+    }
+
+    public String getTombstoneHandlingMode() {
+        return tombstoneHandlingMode;
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusTableRouter.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusTableRouter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+
+/**
+ * Maps Debezium destinations to Unity Catalog table identifiers without Kafka Connect SMTs.
+ */
+public class ZeroBusTableRouter {
+
+    private static final Pattern UC_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private final ZeroBusSinkConfig config;
+    private final Pattern regex;
+
+    public ZeroBusTableRouter(ZeroBusSinkConfig config) {
+        this.config = config;
+        regex = config.getTableMappingRegex() == null ? null : Pattern.compile(config.getTableMappingRegex());
+    }
+
+    public String route(ChangeEvent<Object, Object> record) {
+        String destination = record.destination();
+        if (destination == null || destination.isBlank()) {
+            throw new DebeziumException("ZeroBus table routing requires a non-empty Debezium destination");
+        }
+
+        String target = switch (config.getTableMappingMode()) {
+            case ZeroBusSinkConfig.TABLE_MAPPING_SOURCE -> sourceMapping(destination);
+            case ZeroBusSinkConfig.TABLE_MAPPING_EXPLICIT -> explicitMapping(destination, config.getTableMappingOverrides());
+            case ZeroBusSinkConfig.TABLE_MAPPING_REGEX_MODE -> regexMapping(destination);
+            default -> throw new DebeziumException("Unsupported ZeroBus table mapping mode '" + config.getTableMappingMode() + "'");
+        };
+        validateUnityCatalogTable(target);
+        return target;
+    }
+
+    private String sourceMapping(String destination) {
+        String table = destination.substring(destination.lastIndexOf('.') + 1);
+        return config.getTableMappingDefaultCatalog() + "." + config.getTableMappingDefaultSchema() + "." + table;
+    }
+
+    private String explicitMapping(String destination, Map<String, String> overrides) {
+        String target = overrides.get(destination);
+        if (target == null) {
+            throw new DebeziumException("No ZeroBus table mapping override found for Debezium destination '" + destination + "'");
+        }
+        return target;
+    }
+
+    private String regexMapping(String destination) {
+        Matcher matcher = regex.matcher(destination);
+        if (!matcher.matches()) {
+            throw new DebeziumException("Debezium destination '" + destination + "' does not match ZeroBus table mapping regex");
+        }
+        return matcher.replaceAll(config.getTableMappingReplacement());
+    }
+
+    static void validateUnityCatalogTable(String table) {
+        String[] parts = table == null ? new String[0] : table.split("\\.", -1);
+        if (parts.length != 3) {
+            throw new DebeziumException("ZeroBus target table must be a Unity Catalog identifier '<catalog>.<schema>.<table>': " + table);
+        }
+        for (String part : parts) {
+            if (!UC_IDENTIFIER.matcher(part).matches()) {
+                throw new DebeziumException("Invalid ZeroBus Unity Catalog identifier part '" + part + "' in table '" + table + "'");
+            }
+        }
+    }
+}

--- a/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusWriteResult.java
+++ b/debezium-server-zerobus/src/main/java/io/debezium/server/zerobus/ZeroBusWriteResult.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public record ZeroBusWriteResult(List<Boolean> acknowledged) {
+
+    public ZeroBusWriteResult {
+        acknowledged = List.copyOf(acknowledged);
+    }
+
+    public static ZeroBusWriteResult acknowledged(int recordCount) {
+        return new ZeroBusWriteResult(Collections.nCopies(recordCount, true));
+    }
+
+    public static ZeroBusWriteResult partial(int recordCount, int acknowledgedCount) {
+        List<Boolean> acknowledgements = new ArrayList<>(recordCount);
+        for (int i = 0; i < recordCount; i++) {
+            acknowledgements.add(i < acknowledgedCount);
+        }
+        return new ZeroBusWriteResult(acknowledgements);
+    }
+
+    public boolean allAcknowledged(int expectedCount) {
+        return acknowledged.size() == expectedCount && acknowledged.stream().allMatch(Boolean::booleanValue);
+    }
+}

--- a/debezium-server-zerobus/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
+++ b/debezium-server-zerobus/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
@@ -1,0 +1,1 @@
+io.debezium.server.zerobus.ZeroBusChangeConsumer

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/DatabricksZeroBusClientTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/DatabricksZeroBusClientTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+
+import com.databricks.zerobus.ArrowStreamConfigurationOptions;
+import com.databricks.zerobus.StreamConfigurationOptions;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DynamicMessage;
+
+class DatabricksZeroBusClientTest {
+
+    @Test
+    void writesJsonRecordsThroughJsonStream() throws Exception {
+        FakeSdkAdapter sdk = new FakeSdkAdapter();
+        ZeroBusSinkConfig config = ZeroBusSinkConfigTest.baseConfig();
+
+        DatabricksZeroBusClient client = new DatabricksZeroBusClient(config, sdk, new ZeroBusJsonSerializer(), new ZeroBusProtobufSerializer(), null);
+
+        ZeroBusWriteResult result = client.write("main.bronze.customers", List.of(record()));
+
+        assertThat(result.allAcknowledged(1)).isTrue();
+        assertThat(sdk.jsonRequests).containsExactly("main.bronze.customers");
+        assertThat(sdk.protoRequests).isEmpty();
+        assertThat(sdk.jsonStream.records).hasSize(1);
+        assertThat(sdk.jsonStream.waitedOffsets).containsExactly(11L);
+        client.close();
+    }
+
+    @Test
+    void emptyJsonOffsetFailsInsteadOfAcknowledgingRecords() {
+        FakeSdkAdapter sdk = new FakeSdkAdapter();
+        sdk.jsonStream.offset = Optional.empty();
+        ZeroBusSinkConfig config = ZeroBusSinkConfigTest.baseConfig();
+        DatabricksZeroBusClient client = new DatabricksZeroBusClient(config, sdk, new ZeroBusJsonSerializer(), new ZeroBusProtobufSerializer(), null);
+
+        assertThatThrownBy(() -> client.write("main.bronze.customers", List.of(record())))
+                .isInstanceOf(ZeroBusRetriableException.class)
+                .hasMessageContaining("did not return a durable offset");
+    }
+
+    @Test
+    void writesProtobufRecordsThroughProtoStream() throws Exception {
+        FakeSdkAdapter sdk = new FakeSdkAdapter();
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("record.format", "protobuf")
+                .build());
+        config.validate();
+        ZeroBusProtobufSerializer serializer = new ZeroBusProtobufSerializer();
+
+        DatabricksZeroBusClient client = new DatabricksZeroBusClient(config, sdk, new ZeroBusJsonSerializer(), serializer, null);
+
+        ZeroBusWriteResult result = client.write("main.bronze.customers", List.of(record()));
+
+        DynamicMessage message = DynamicMessage.parseFrom(serializer.descriptor(), sdk.protoStream.records.get(0));
+        assertThat(result.allAcknowledged(1)).isTrue();
+        assertThat(sdk.jsonRequests).isEmpty();
+        assertThat(sdk.protoRequests).containsExactly("main.bronze.customers");
+        assertThat(sdk.protoDescriptor.getName()).isEqualTo("DebeziumZeroBusRecord");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("operation"))).isEqualTo("update");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("value"))).isEqualTo("{\"after\":{\"id\":1}}");
+        assertThat(sdk.protoStream.waitedOffsets).containsExactly(19L);
+        client.close();
+    }
+
+    @Test
+    void writesArrowRecordsThroughArrowStream() throws Exception {
+        FakeSdkAdapter sdk = new FakeSdkAdapter();
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("record.format", "arrow")
+                .build());
+        config.validate();
+        ZeroBusArrowSerializer serializer = new ZeroBusArrowSerializer();
+
+        DatabricksZeroBusClient client = new DatabricksZeroBusClient(config, sdk, new ZeroBusJsonSerializer(), new ZeroBusProtobufSerializer(), serializer);
+
+        ZeroBusWriteResult result = client.write("main.bronze.customers", List.of(record()));
+
+        assertThat(result.allAcknowledged(1)).isTrue();
+        assertThat(sdk.jsonRequests).isEmpty();
+        assertThat(sdk.protoRequests).isEmpty();
+        assertThat(sdk.arrowRequests).containsExactly("main.bronze.customers");
+        assertThat(sdk.arrowSchema.getFields()).extracting(field -> field.getName()).containsExactly(
+                "target_table",
+                "destination",
+                "partition",
+                "operation",
+                "idempotency_key",
+                "key",
+                "value",
+                "source_position",
+                "headers");
+        assertThat(sdk.arrowStream.records).containsExactly("{\"after\":{\"id\":1}}");
+        assertThat(sdk.arrowStream.waitedOffsets).containsExactly(23L);
+        client.close();
+    }
+
+    private static ZeroBusRecord record() {
+        return new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                0,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1}}",
+                Map.of("offset.lsn", "100"),
+                Map.of("source.lsn", "100"),
+                ZeroBusOperation.UPDATE,
+                "stable-idempotency-key");
+    }
+
+    private static class FakeSdkAdapter implements ZeroBusSdkAdapter {
+        private final FakeJsonStream jsonStream = new FakeJsonStream();
+        private final FakeProtoStream protoStream = new FakeProtoStream();
+        private final FakeArrowStream arrowStream = new FakeArrowStream();
+        private final List<String> jsonRequests = new ArrayList<>();
+        private final List<String> protoRequests = new ArrayList<>();
+        private final List<String> arrowRequests = new ArrayList<>();
+        private DescriptorProto protoDescriptor;
+        private Schema arrowSchema;
+
+        @Override
+        public CompletableFuture<ZeroBusJsonStreamAdapter> createJsonStream(String targetTable,
+                                                                            String clientId,
+                                                                            String clientSecret,
+                                                                            StreamConfigurationOptions options) {
+            jsonRequests.add(targetTable);
+            return CompletableFuture.completedFuture(jsonStream);
+        }
+
+        @Override
+        public CompletableFuture<ZeroBusProtoStreamAdapter> createProtoStream(String targetTable,
+                                                                              DescriptorProto descriptor,
+                                                                              String clientId,
+                                                                              String clientSecret,
+                                                                              StreamConfigurationOptions options) {
+            protoRequests.add(targetTable);
+            protoDescriptor = descriptor;
+            return CompletableFuture.completedFuture(protoStream);
+        }
+
+        @Override
+        public CompletableFuture<ZeroBusArrowStreamAdapter> createArrowStream(String targetTable,
+                                                                              Schema schema,
+                                                                              String clientId,
+                                                                              String clientSecret,
+                                                                              ArrowStreamConfigurationOptions options) {
+            arrowRequests.add(targetTable);
+            arrowSchema = schema;
+            return CompletableFuture.completedFuture(arrowStream);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class FakeJsonStream implements ZeroBusJsonStreamAdapter {
+        private final List<String> records = new ArrayList<>();
+        private final List<Long> waitedOffsets = new ArrayList<>();
+        private Optional<Long> offset = Optional.of(11L);
+
+        @Override
+        public Optional<Long> ingestRecordsOffset(List<String> records) {
+            this.records.addAll(records);
+            return offset;
+        }
+
+        @Override
+        public void waitForOffset(long offset) {
+            waitedOffsets.add(offset);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class FakeProtoStream implements ZeroBusProtoStreamAdapter {
+        private final List<byte[]> records = new ArrayList<>();
+        private final List<Long> waitedOffsets = new ArrayList<>();
+
+        @Override
+        public Optional<Long> ingestRecordsOffset(List<byte[]> records) {
+            this.records.addAll(records);
+            return Optional.of(19L);
+        }
+
+        @Override
+        public void waitForOffset(long offset) {
+            waitedOffsets.add(offset);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class FakeArrowStream implements ZeroBusArrowStreamAdapter {
+        private final List<String> records = new ArrayList<>();
+        private final List<Long> waitedOffsets = new ArrayList<>();
+
+        @Override
+        public Optional<Long> ingestBatch(VectorSchemaRoot root) {
+            VarCharVector value = (VarCharVector) root.getVector("value");
+            for (int row = 0; row < root.getRowCount(); row++) {
+                records.add(value.getObject(row).toString());
+            }
+            return Optional.of(23L);
+        }
+
+        @Override
+        public void waitForOffset(long offset) {
+            waitedOffsets.add(offset);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusArrowSerializerTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusArrowSerializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+class ZeroBusArrowSerializerTest {
+
+    @Test
+    void serializesEnvelopeAsArrowBatch() {
+        ZeroBusArrowSerializer serializer = new ZeroBusArrowSerializer();
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                0,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1,\"name\":\"Anne\"}}",
+                Map.of("offset.lsn", "100", "offset.txId", "7"),
+                Map.of("source.lsn", "100"),
+                ZeroBusOperation.UPDATE,
+                "server.inventory.customers|partition=0|key={\"id\":1}|source_position=offset.lsn=100&offset.txId=7");
+
+        try (VectorSchemaRoot root = serializer.serialize(java.util.List.of(record))) {
+            assertThat(root.getRowCount()).isEqualTo(1);
+            assertThat(string(root, "target_table", 0)).isEqualTo("main.bronze.customers");
+            assertThat(string(root, "destination", 0)).isEqualTo("server.inventory.customers");
+            assertThat(((IntVector) root.getVector("partition")).get(0)).isEqualTo(0);
+            assertThat(string(root, "operation", 0)).isEqualTo("update");
+            assertThat(string(root, "key", 0)).isEqualTo("{\"id\":1}");
+            assertThat(string(root, "value", 0)).isEqualTo("{\"after\":{\"id\":1,\"name\":\"Anne\"}}");
+            assertThat(string(root, "source_position", 0)).contains("\"offset.lsn\":\"100\"");
+            assertThat(string(root, "headers", 0)).contains("\"source.lsn\":\"100\"");
+            assertThat(string(root, "idempotency_key", 0)).contains("source_position=offset.lsn=100");
+        }
+        finally {
+            serializer.close();
+        }
+    }
+
+    @Test
+    void schemaMatchesZeroBusEnvelopeFields() {
+        ZeroBusArrowSerializer serializer = new ZeroBusArrowSerializer();
+
+        assertThat(serializer.schema().getFields())
+                .extracting(field -> field.getName() + ":" + field.getType())
+                .containsExactly(
+                        "target_table:Utf8",
+                        "destination:Utf8",
+                        "partition:Int(32, true)",
+                        "operation:Utf8",
+                        "idempotency_key:Utf8",
+                        "key:Utf8",
+                        "value:Utf8",
+                        "source_position:Utf8",
+                        "headers:Utf8");
+        serializer.close();
+    }
+
+    private static String string(VectorSchemaRoot root, String field, int row) {
+        return ((VarCharVector) root.getVector(field)).getObject(row).toString();
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusBatchWriterTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusBatchWriterTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.embedded.EmbeddedEngineChangeEvent;
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.Header;
+
+class ZeroBusBatchWriterTest {
+
+    @Test
+    void successfulAckReturnsProcessedRecords() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+        List<ChangeEvent<Object, Object>> records = List.of(record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}"));
+
+        List<ChangeEvent<Object, Object>> processed = writer.write(records);
+
+        assertThat(processed).containsExactlyElementsOf(records);
+        assertThat(client.targets).containsExactly("main.bronze.customers");
+        assertThat(client.records.get(0).operation()).isEqualTo(ZeroBusOperation.CHANGE);
+        assertThat(client.records.get(0).idempotencyKey()).contains("server.inventory.customers|partition=0|key=1|headers=source.lsn=100");
+    }
+
+    @Test
+    void sourceRecordOffsetDrivesIdempotencyKeyWhenAvailable() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(embeddedRecord(
+                "server.inventory.customers",
+                "1",
+                "{\"after\":{\"id\":1}}",
+                Map.of("server", "inventory"),
+                Map.of("lsn", 123456789L, "txId", 42L, "event_serial_no", 3))));
+
+        ZeroBusRecord written = client.records.get(0);
+        assertThat(written.sourcePosition()).containsEntry("offset.lsn", "123456789");
+        assertThat(written.sourcePosition()).containsEntry("offset.txId", "42");
+        assertThat(written.sourcePosition()).containsEntry("offset.event_serial_no", "3");
+        assertThat(written.idempotencyKey())
+                .contains("source_position=")
+                .contains("offset.lsn=123456789")
+                .doesNotContain("headers=source.lsn=100");
+    }
+
+    @Test
+    void tombstoneEventIsMappedWhenValueIsNull() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(record("server.inventory.customers", "1", null)));
+
+        assertThat(client.records.get(0).operation()).isEqualTo(ZeroBusOperation.TOMBSTONE);
+        assertThat(client.records.get(0).value()).isNull();
+    }
+
+    @Test
+    void deleteEnvelopeOperationIsMappedFromJsonOpD() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(record("server.inventory.customers", "1", "{\"before\":{\"id\":1},\"after\":null,\"op\":\"d\"}")));
+
+        assertThat(client.records.get(0).operation()).isEqualTo(ZeroBusOperation.DELETE);
+        assertThat(client.records.get(0).value()).isEqualTo("{\"before\":{\"id\":1},\"after\":null,\"op\":\"d\"}");
+    }
+
+    @Test
+    void droppedTombstoneIsMarkedProcessedWithoutWrite() throws Exception {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("tombstone.handling.mode", "drop")
+                .build());
+        config.validate();
+        CapturingClient client = new CapturingClient();
+
+        List<ChangeEvent<Object, Object>> processed = writer(client, config)
+                .write(List.of(record("server.inventory.customers", "1", null)));
+
+        assertThat(processed).hasSize(1);
+        assertThat(client.records).isEmpty();
+    }
+
+    @Test
+    void partialAckFailsBatch() {
+        ZeroBusClient client = (targetTable, records) -> ZeroBusWriteResult.partial(records.size(), 1);
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        assertThatThrownBy(() -> writer.write(List.of(
+                record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}"),
+                record("server.inventory.customers", "2", "{\"after\":{\"id\":2}}"))))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("partially acknowledged 1 result(s) for 2 record(s)");
+    }
+
+    @Test
+    void preservesSourceOrderAcrossInterleavedTargetTables() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(
+                record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}"),
+                record("server.inventory.orders", "10", "{\"after\":{\"id\":10}}"),
+                record("server.inventory.customers", "2", "{\"after\":{\"id\":2}}")));
+
+        assertThat(client.targets).containsExactly(
+                "main.bronze.customers",
+                "main.bronze.orders",
+                "main.bronze.customers");
+        assertThat(client.records).extracting(ZeroBusRecord::destination).containsExactly(
+                "server.inventory.customers",
+                "server.inventory.orders",
+                "server.inventory.customers");
+    }
+
+    @Test
+    void batchesConsecutiveRecordsForSameTargetTable() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("batch.size", "2")
+                .build());
+        config.validate();
+
+        writer(client, config).write(List.of(
+                record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}"),
+                record("server.inventory.customers", "2", "{\"after\":{\"id\":2}}"),
+                record("server.inventory.customers", "3", "{\"after\":{\"id\":3}}")));
+
+        assertThat(client.targets).containsExactly("main.bronze.customers", "main.bronze.customers");
+        assertThat(client.writeSizes).containsExactly(2, 1);
+    }
+
+    @Test
+    void retryableFailureRetriesWithSameIdempotencyKey() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        List<String> idempotencyKeys = new ArrayList<>();
+        ZeroBusClient client = (targetTable, records) -> {
+            attempts.incrementAndGet();
+            idempotencyKeys.add(records.get(0).idempotencyKey());
+            if (attempts.get() == 1) {
+                throw new ZeroBusRetriableException("retry");
+            }
+            return ZeroBusWriteResult.acknowledged(records.size());
+        };
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("retry.interval.ms", "0")
+                .build());
+        config.validate();
+
+        writer(client, config).write(List.of(record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}")));
+
+        assertThat(attempts).hasValue(2);
+        assertThat(idempotencyKeys).hasSize(2).containsOnly(idempotencyKeys.get(0));
+    }
+
+    @Test
+    void retriesConfigCountsRetriesAfterInitialAttempt() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        ZeroBusClient client = (targetTable, records) -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new ZeroBusRetriableException("retry once");
+            }
+            return ZeroBusWriteResult.acknowledged(records.size());
+        };
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("retries", "1")
+                .with("retry.interval.ms", "0")
+                .build());
+        config.validate();
+
+        writer(client, config).write(List.of(record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}")));
+
+        assertThat(attempts).hasValue(2);
+    }
+
+    @Test
+    void idempotencyKeyEscapesDelimiterBearingValues() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(
+                record("srv", "|partition=0|key=r2", "{\"after\":{\"id\":1}}", List.of()),
+                record("srv|partition=0|key=", "r2", "{\"after\":{\"id\":2}}", List.of())));
+
+        assertThat(client.records)
+                .extracting(ZeroBusRecord::idempotencyKey)
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    void unknownEnvelopeOperationMapsToChange() throws Exception {
+        CapturingClient client = new CapturingClient();
+        ZeroBusBatchWriter writer = writer(client, ZeroBusSinkConfigTest.baseConfig());
+
+        writer.write(List.of(record("server.inventory.customers", "1", "{\"op\":\"t\"}")));
+
+        assertThat(client.records.get(0).operation()).isEqualTo(ZeroBusOperation.CHANGE);
+    }
+
+    @Test
+    void idempotencyCanBeDisabled() throws Exception {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("idempotency.mode", "none")
+                .build());
+        config.validate();
+        CapturingClient client = new CapturingClient();
+
+        writer(client, config).write(List.of(record("server.inventory.customers", "1", "{\"after\":{\"id\":1}}")));
+
+        assertThat(client.records.get(0).idempotencyKey()).isNull();
+    }
+
+    private static ZeroBusBatchWriter writer(ZeroBusClient client, ZeroBusSinkConfig config) {
+        ZeroBusTableRouter router = new ZeroBusTableRouter(config);
+        return new ZeroBusBatchWriter(config, client, new ZeroBusRecordMapper(router, config));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChangeEvent<Object, Object> record(String destination, String key, String value) {
+        Header<Object> header = mock(Header.class);
+        when(header.getKey()).thenReturn("source.lsn");
+        when(header.getValue()).thenReturn("100");
+        return record(destination, key, value, List.of(header));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChangeEvent<Object, Object> record(String destination, String key, String value, List<Header<Object>> headers) {
+        ChangeEvent<Object, Object> record = mock(ChangeEvent.class);
+        when(record.destination()).thenReturn(destination);
+        when(record.partition()).thenReturn(0);
+        when(record.key()).thenReturn(key);
+        when(record.value()).thenReturn(value);
+        when(record.headers()).thenReturn(headers);
+        return record;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChangeEvent<Object, Object> embeddedRecord(String destination, String key, String value,
+                                                              Map<String, ?> sourcePartition, Map<String, ?> sourceOffset) {
+        EmbeddedEngineChangeEvent<Object, Object, Object> record = mock(EmbeddedEngineChangeEvent.class);
+        Header<Object> header = mock(Header.class);
+        SourceRecord sourceRecord = new SourceRecord(
+                sourcePartition,
+                sourceOffset,
+                destination,
+                0,
+                null,
+                key,
+                null,
+                value);
+        when(header.getKey()).thenReturn("source.lsn");
+        when(header.getValue()).thenReturn("100");
+        when(record.sourceRecord()).thenReturn(sourceRecord);
+        when(record.destination()).thenReturn(destination);
+        when(record.partition()).thenReturn(0);
+        when(record.key()).thenReturn(key);
+        when(record.value()).thenReturn(value);
+        when(record.headers()).thenReturn(List.of(header));
+        return record;
+    }
+
+    private static class CapturingClient implements ZeroBusClient {
+        private final List<String> targets = new ArrayList<>();
+        private final List<ZeroBusRecord> records = new ArrayList<>();
+        private final List<Integer> writeSizes = new ArrayList<>();
+
+        @Override
+        public ZeroBusWriteResult write(String targetTable, List<ZeroBusRecord> records) {
+            targets.add(targetTable);
+            writeSizes.add(records.size());
+            this.records.addAll(records);
+            return ZeroBusWriteResult.acknowledged(records.size());
+        }
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusChangeConsumerTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusChangeConsumerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.server.ConnectionValidationResult;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+class ZeroBusChangeConsumerTest {
+
+    @Test
+    void marksProcessedOnlyAfterDurableAck() throws Exception {
+        ZeroBusChangeConsumer consumer = new ZeroBusChangeConsumer();
+        consumer.initWithConfig(config(), (targetTable, records) -> ZeroBusWriteResult.acknowledged(records.size()));
+        ChangeEvent<Object, Object> record = ZeroBusTableRouterTest.record("server.inventory.customers");
+
+        @SuppressWarnings("unchecked")
+        DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer = mock(DebeziumEngine.RecordCommitter.class);
+        consumer.handleBatch(List.of(record), committer);
+
+        verify(committer, times(1)).markProcessed(record);
+        verify(committer, times(1)).markBatchFinished();
+    }
+
+    @Test
+    void failureDoesNotMarkProcessedOrBatchFinished() throws Exception {
+        ZeroBusChangeConsumer consumer = new ZeroBusChangeConsumer();
+        consumer.initWithConfig(config(), (targetTable, records) -> {
+            throw new ZeroBusRetriableException("retry");
+        });
+        ChangeEvent<Object, Object> record = ZeroBusTableRouterTest.record("server.inventory.customers");
+
+        @SuppressWarnings("unchecked")
+        DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer = mock(DebeziumEngine.RecordCommitter.class);
+        try {
+            consumer.handleBatch(List.of(record), committer);
+        }
+        catch (Exception ignored) {
+        }
+
+        verify(committer, never()).markProcessed(record);
+        verify(committer, never()).markBatchFinished();
+    }
+
+    @Test
+    void validateConnectionReturnsSuccessfulForValidConfig() {
+        ConnectionValidationResult result = new ZeroBusChangeConsumer().validateConnection(Map.of(
+                "endpoint", "https://zerobus.example",
+                "workspace.url", "https://workspace.example",
+                "authentication.type", "oauth2",
+                "authentication.oauth2.client-id", "client",
+                "authentication.oauth2.client-secret", "secret",
+                "table.mapping.mode", "source",
+                "table.mapping.default.catalog", "main",
+                "table.mapping.default.schema", "bronze"));
+
+        org.assertj.core.api.Assertions.assertThat(result.valid()).isTrue();
+    }
+
+    @Test
+    void validateConnectionReturnsFailedForInvalidConfig() {
+        ConnectionValidationResult result = new ZeroBusChangeConsumer().validateConnection(Map.of(
+                "workspace.url", "https://workspace.example",
+                "authentication.type", "oauth2",
+                "authentication.oauth2.client-id", "client",
+                "authentication.oauth2.client-secret", "secret",
+                "table.mapping.mode", "source",
+                "table.mapping.default.catalog", "main",
+                "table.mapping.default.schema", "bronze"));
+
+        org.assertj.core.api.Assertions.assertThat(result.valid()).isFalse();
+        org.assertj.core.api.Assertions.assertThat(result.message()).contains("endpoint");
+    }
+
+    private static org.eclipse.microprofile.config.Config config() {
+        return new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "debezium.sink.zerobus.endpoint", "https://zerobus.example",
+                        "debezium.sink.zerobus.workspace.url", "https://workspace.example",
+                        "debezium.sink.zerobus.authentication.type", "oauth2",
+                        "debezium.sink.zerobus.authentication.oauth2.client-id", "client",
+                        "debezium.sink.zerobus.authentication.oauth2.client-secret", "secret",
+                        "debezium.sink.zerobus.table.mapping.mode", "source",
+                        "debezium.sink.zerobus.table.mapping.default.catalog", "main",
+                        "debezium.sink.zerobus.table.mapping.default.schema", "bronze",
+                        "debezium.sink.zerobus.retries", "1",
+                        "debezium.sink.zerobus.retry.interval.ms", "0"),
+                        "zerobus-test"))
+                .build();
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusJsonSerializerTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusJsonSerializerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ZeroBusJsonSerializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesDebeziumJsonStringsAsNestedJson() throws Exception {
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                0,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1,\"name\":\"Anne\"}}",
+                Map.of("offset.lsn", "100", "offset.txId", "7"),
+                Map.of("source.lsn", "100"),
+                ZeroBusOperation.CHANGE,
+                "server.inventory.customers|partition=0|key={\"id\":1}|source_position=offset.lsn=100&offset.txId=7");
+
+        JsonNode json = mapper.readTree(new ZeroBusJsonSerializer().serialize(record));
+
+        assertThat(json.get("target_table").asText()).isEqualTo("main.bronze.customers");
+        assertThat(json.get("partition").asInt()).isEqualTo(0);
+        assertThat(json.get("operation").asText()).isEqualTo("change");
+        assertThat(json.get("key").get("id").asInt()).isEqualTo(1);
+        assertThat(json.get("value").get("after").get("name").asText()).isEqualTo("Anne");
+        assertThat(json.get("source_position").get("offset.lsn").asText()).isEqualTo("100");
+        assertThat(json.get("headers").get("source.lsn").asText()).isEqualTo("100");
+        assertThat(json.get("idempotency_key").asText()).contains("source_position=offset.lsn=100");
+    }
+
+    @Test
+    void preservesNonJsonStringsAsText() throws Exception {
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                null,
+                "plain-key",
+                "plain-value",
+                Map.of(),
+                Map.of(),
+                ZeroBusOperation.CHANGE,
+                "stable-key");
+
+        JsonNode json = mapper.readTree(new ZeroBusJsonSerializer().serialize(record));
+
+        assertThat(json.get("key").asText()).isEqualTo("plain-key");
+        assertThat(json.get("value").asText()).isEqualTo("plain-value");
+    }
+
+    @Test
+    void serializesDisabledIdempotencyAsNull() throws Exception {
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                0,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1}}",
+                Map.of(),
+                Map.of(),
+                ZeroBusOperation.CHANGE,
+                null);
+
+        JsonNode json = mapper.readTree(new ZeroBusJsonSerializer().serialize(record));
+
+        assertThat(json.get("idempotency_key").isNull()).isTrue();
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusProtobufSerializerTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusProtobufSerializerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.DynamicMessage;
+
+class ZeroBusProtobufSerializerTest {
+
+    @Test
+    void serializesEnvelopeAsDynamicProtobuf() throws Exception {
+        ZeroBusProtobufSerializer serializer = new ZeroBusProtobufSerializer();
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                0,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1,\"name\":\"Anne\"}}",
+                Map.of("offset.lsn", "100", "offset.txId", "7"),
+                Map.of("source.lsn", "100"),
+                ZeroBusOperation.UPDATE,
+                "server.inventory.customers|partition=0|key={\"id\":1}|source_position=offset.lsn=100&offset.txId=7");
+
+        DynamicMessage message = DynamicMessage.parseFrom(serializer.descriptor(), serializer.serialize(record));
+
+        assertThat(message.getField(serializer.descriptor().findFieldByName("target_table"))).isEqualTo("main.bronze.customers");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("destination"))).isEqualTo("server.inventory.customers");
+        assertThat(message.hasField(serializer.descriptor().findFieldByName("partition"))).isTrue();
+        assertThat(message.getField(serializer.descriptor().findFieldByName("partition"))).isEqualTo(0);
+        assertThat(message.getField(serializer.descriptor().findFieldByName("operation"))).isEqualTo("update");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("key"))).isEqualTo("{\"id\":1}");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("value"))).isEqualTo("{\"after\":{\"id\":1,\"name\":\"Anne\"}}");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("source_position")).toString()).contains("\"offset.lsn\":\"100\"");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("headers")).toString()).contains("\"source.lsn\":\"100\"");
+        assertThat(message.getField(serializer.descriptor().findFieldByName("idempotency_key")).toString()).contains("source_position=offset.lsn=100");
+    }
+
+    @Test
+    void descriptorMatchesZeroBusEnvelopeFields() {
+        ZeroBusProtobufSerializer serializer = new ZeroBusProtobufSerializer();
+
+        assertThat(serializer.descriptorProto().getName()).isEqualTo("DebeziumZeroBusRecord");
+        assertThat(serializer.descriptorProto().getFieldList())
+                .extracting(field -> field.getName() + ":" + field.getNumber())
+                .containsExactly(
+                        "target_table:1",
+                        "destination:2",
+                        "partition:3",
+                        "operation:4",
+                        "idempotency_key:5",
+                        "key:6",
+                        "value:7",
+                        "source_position:8",
+                        "headers:9");
+    }
+
+    @Test
+    void nullPartitionIsDistinctFromPartitionZero() throws Exception {
+        ZeroBusProtobufSerializer serializer = new ZeroBusProtobufSerializer();
+        ZeroBusRecord record = new ZeroBusRecord(
+                "main.bronze.customers",
+                "server.inventory.customers",
+                null,
+                "{\"id\":1}",
+                "{\"after\":{\"id\":1}}",
+                Map.of(),
+                Map.of(),
+                ZeroBusOperation.UPDATE,
+                "stable-idempotency-key");
+
+        DynamicMessage message = DynamicMessage.parseFrom(serializer.descriptor(), serializer.serialize(record));
+
+        assertThat(message.hasField(serializer.descriptor().findFieldByName("partition"))).isFalse();
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusSinkConfigTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusSinkConfigTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+
+class ZeroBusSinkConfigTest {
+
+    @Test
+    void rejectsMissingEndpoint() {
+        assertThatThrownBy(() -> configWithout("endpoint").validate())
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("endpoint");
+    }
+
+    @Test
+    void rejectsMissingAuthentication() {
+        assertThatThrownBy(() -> configWithout("authentication.type").validate())
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("authentication.type");
+    }
+
+    @Test
+    void rejectsMissingWorkspaceUrl() {
+        assertThatThrownBy(() -> configWithout("workspace.url").validate())
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("workspace.url");
+    }
+
+    @Test
+    void rejectsUnsupportedRecordFormat() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.with("record.format", "avro");
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("record format");
+    }
+
+    @Test
+    void acceptsProtobufRecordFormat() {
+        Configuration.Builder builder = baseBuilder();
+        builder.with("record.format", "protobuf");
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(builder.build());
+
+        config.validate();
+
+        assertThat(config.getRecordFormat()).isEqualTo("protobuf");
+    }
+
+    @Test
+    void acceptsArrowRecordFormat() {
+        Configuration.Builder builder = baseBuilder();
+        builder.with("record.format", "arrow");
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(builder.build());
+
+        config.validate();
+
+        assertThat(config.getRecordFormat()).isEqualTo("arrow");
+    }
+
+    @Test
+    void rejectsUnsupportedIdempotencyMode() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.with("idempotency.mode", "service");
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("idempotency mode");
+    }
+
+    @Test
+    void rejectsInvalidMaxInflightBatches() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.with("max.inflight.batches", 0);
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("max.inflight.batches");
+    }
+
+    @Test
+    void rejectsUnsupportedTombstoneHandlingMode() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.with("tombstone.handling.mode", "rewrite");
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("tombstone handling mode");
+    }
+
+    @Test
+    void rejectsMissingSourceMappingDefaults() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.without("table.mapping.default.schema");
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("table.mapping.default.schema");
+    }
+
+    @Test
+    void rejectsInvalidRegexMappingPattern() {
+        assertThatThrownBy(() -> {
+            Configuration.Builder builder = baseBuilder();
+            builder.with("table.mapping.mode", "regex");
+            builder.with("table.mapping.regex", "(");
+            builder.with("table.mapping.replacement", "main.bronze.$1");
+            new ZeroBusSinkConfig(builder.build()).validate();
+        })
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("table mapping regex");
+    }
+
+    @Test
+    void acceptsValidSourceMappingConfig() {
+        ZeroBusSinkConfig config = baseConfig();
+
+        config.validate();
+
+        assertThat(config.getEndpoint()).isEqualTo("https://zerobus.example");
+        assertThat(config.getWorkspaceUrl()).isEqualTo("https://workspace.example");
+        assertThat(config.getAuthenticationType()).isEqualTo("oauth2");
+        assertThat(config.getRecordFormat()).isEqualTo("json");
+        assertThat(config.getBatchSize()).isEqualTo(200);
+        assertThat(config.getMaxInflightRecords()).isEqualTo(1_000_000);
+        assertThat(config.getMaxInflightBatches()).isEqualTo(1_000);
+        assertThat(config.getIdempotencyMode()).isEqualTo("source");
+    }
+
+    private ZeroBusSinkConfig configWithout(String key) {
+        Configuration.Builder builder = baseBuilder();
+        builder.without(key);
+        return new ZeroBusSinkConfig(builder.build());
+    }
+
+    static ZeroBusSinkConfig baseConfig() {
+        return new ZeroBusSinkConfig(baseBuilder().build());
+    }
+
+    static Configuration.Builder baseBuilder() {
+        return Configuration.create()
+                .with("endpoint", "https://zerobus.example")
+                .with("workspace.url", "https://workspace.example")
+                .with("authentication.type", "oauth2")
+                .with("authentication.oauth2.client-id", "client")
+                .with("authentication.oauth2.client-secret", "secret")
+                .with("table.mapping.mode", "source")
+                .with("table.mapping.default.catalog", "main")
+                .with("table.mapping.default.schema", "bronze");
+    }
+}

--- a/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusTableRouterTest.java
+++ b/debezium-server-zerobus/src/test/java/io/debezium/server/zerobus/ZeroBusTableRouterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.zerobus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+
+class ZeroBusTableRouterTest {
+
+    @Test
+    void mapsSourceDestinationToDefaultUnityCatalogTable() {
+        ZeroBusTableRouter router = new ZeroBusTableRouter(ZeroBusSinkConfigTest.baseConfig());
+
+        assertThat(router.route(record("server.inventory.customers")))
+                .isEqualTo("main.bronze.customers");
+    }
+
+    @Test
+    void mapsExplicitDestinationOverride() {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("table.mapping.mode", "explicit")
+                .with("table.mapping.overrides", "server.inventory.customers=main.silver.customer_dim")
+                .build());
+        config.validate();
+
+        assertThat(new ZeroBusTableRouter(config).route(record("server.inventory.customers")))
+                .isEqualTo("main.silver.customer_dim");
+    }
+
+    @Test
+    void mapsRegexDestinationWithoutKafkaConnectSmt() {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("table.mapping.mode", "regex")
+                .with("table.mapping.regex", "server\\.inventory\\.(.*)")
+                .with("table.mapping.replacement", "main.bronze.$1")
+                .build());
+        config.validate();
+
+        assertThat(new ZeroBusTableRouter(config).route(record("server.inventory.orders")))
+                .isEqualTo("main.bronze.orders");
+    }
+
+    @Test
+    void rejectsInvalidUnityCatalogTarget() {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("table.mapping.mode", "explicit")
+                .with("table.mapping.overrides", "server.inventory.customers=main.bad-schema.customer_dim")
+                .build());
+
+        config.validate();
+
+        assertThat(new ZeroBusTableRouter(config).route(record("server.inventory.customers")))
+                .isEqualTo("main.bad-schema.customer_dim");
+    }
+
+    @Test
+    void rejectsUnityCatalogNamesWithDisallowedCharacters() {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("table.mapping.mode", "explicit")
+                .with("table.mapping.overrides", "server.inventory.customers=main.bad/schema.customer_dim")
+                .build());
+
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("Invalid ZeroBus Unity Catalog identifier");
+    }
+
+    @Test
+    void rejectsInvalidRegexReplacementDuringConfigValidation() {
+        ZeroBusSinkConfig config = new ZeroBusSinkConfig(ZeroBusSinkConfigTest.baseBuilder()
+                .with("table.mapping.mode", "regex")
+                .with("table.mapping.regex", "server\\.inventory\\.(.*)")
+                .with("table.mapping.replacement", "main.bronze.$2")
+                .build());
+
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("table.mapping.replacement");
+    }
+
+    @SuppressWarnings("unchecked")
+    static ChangeEvent<Object, Object> record(String destination) {
+        ChangeEvent<Object, Object> record = mock(ChangeEvent.class);
+        when(record.destination()).thenReturn(destination);
+        when(record.key()).thenReturn("1");
+        when(record.value()).thenReturn("{\"after\":{\"id\":1}}");
+        when(record.headers()).thenReturn(List.of());
+        return record;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <module>debezium-server-eventhubs</module>
         <module>debezium-server-http</module>
         <module>debezium-server-jdbc</module>
+        <module>debezium-server-zerobus</module>
         <module>debezium-server-redis</module>
         <module>debezium-server-dist</module>
         <module>debezium-server-kafka</module>


### PR DESCRIPTION
## Summary

Adds a native `zerobus` sink module for Debezium Server. The sink writes Debezium Server change-event batches to Databricks ZeroBus without using Kafka producer or Kafka Connect APIs.

Key pieces:

- new `debezium-server-zerobus` module and CDI sink registration
- ZeroBus SDK-backed JSON, protobuf, and Arrow writers
- Unity Catalog table routing by source table, explicit override, or regex mapping
- source-position idempotency keys using Debezium partition/offset metadata
- ack-before-offset behavior: records are marked processed only after durable sink acknowledgement
- delete versus tombstone handling, including configurable tombstone drop behavior
- BOM, root module, distribution dependency, and `sink-zerobus` custom distribution profile wiring
- module documentation and an upstream contribution packet describing design boundaries and follow-ups

## Verification

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home/bin:$PATH mvn -B -s /tmp/debezium-maven-google-settings.xml -pl debezium-server-zerobus test -DskipITs -Dquick -DskipTests=false -Dformat.skip=true`
  - passed: 38 tests, 0 failures, 0 errors, 0 skipped
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home/bin:$PATH mvn -B -s /tmp/debezium-maven-google-settings.xml -Dquick -DskipITs -DskipTests -Dformat.skip=true -Passembly -Pcustom-distribution,sink-zerobus package`
  - passed: full reactor package including `Debezium Server ZeroBus Sink Adapter` and `Debezium Server Distribution`
- `git diff --check`
  - passed
- staged secret scan
  - no raw OAuth/client secrets found; docs use environment variable placeholders

## Local smoke proof

A local terminal smoke test with Postgres -> Debezium Server -> Arrow -> ZeroBus -> Unity Catalog Delta returned snapshot/read plus create/update/delete rows with source-position LSN metadata.

## Notes

This is opened as a draft for maintainer/API-shape review. Remaining design questions include the exact production table lifecycle/schema-evolution contract, service-side replay/idempotency guidance, and whether maintainers prefer source-table-shaped protobuf/Arrow records over the stable Debezium envelope used here.