### PR TITLE
debezium/dbz#2078 Guard sink-to-storage property remapping against explicit storage config

### DIFF
--- a/debezium-server-core/src/main/java/io/debezium/server/configuration/DebeziumServerConfigSourceFactory.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/configuration/DebeziumServerConfigSourceFactory.java
@@ -84,12 +84,24 @@ public class DebeziumServerConfigSourceFactory implements ConfigSourceFactory {
         ConfigValue sink = context.getValue(PROP_SINK_TYPE);
         if (sink != null && sink.getValue() != null) {
             remapped.put(QUARKUS_DEBEZIUM_PREFIX + "name", sink.getValue());
-            configToProperties(context, remapped, PROP_SINK_PREFIX + sink.getValue() + ".",
-                    QUARKUS_DEBEZIUM_PREFIX + SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + sink.getValue() + ".",
-                    false);
-            configToProperties(context, remapped, PROP_SINK_PREFIX + sink.getValue() + ".",
-                    QUARKUS_DEBEZIUM_PREFIX + PROP_OFFSET_STORAGE_PREFIX + sink.getValue() + ".",
-                    false);
+            String sinkPrefix = PROP_SINK_PREFIX + sink.getValue() + ".";
+
+            // The sink connection properties are reused for the schema history and offset storage
+            // namespaces as a convenience when the same technology is used for both the sink and the
+            // storage. This is only done when the corresponding storage namespace has not been
+            // configured explicitly; otherwise the copied sink properties could silently override the
+            // user's explicit storage configuration (e.g. when the sink and storage use different
+            // property names for the same concept) or leak sink-specific properties into the storage
+            // namespaces where they have no meaning.
+            String schemaHistoryPrefix = QUARKUS_DEBEZIUM_PREFIX + SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + sink.getValue() + ".";
+            if (!hasPropertyWithPrefix(context, remapped, schemaHistoryPrefix)) {
+                configToProperties(context, remapped, sinkPrefix, schemaHistoryPrefix, false);
+            }
+
+            String offsetStoragePrefix = QUARKUS_DEBEZIUM_PREFIX + PROP_OFFSET_STORAGE_PREFIX + sink.getValue() + ".";
+            if (!hasPropertyWithPrefix(context, remapped, offsetStoragePrefix)) {
+                configToProperties(context, remapped, sinkPrefix, offsetStoragePrefix, false);
+            }
         }
 
         var transforms = context.getValue(PROP_TRANSFORMS);
@@ -163,6 +175,23 @@ public class DebeziumServerConfigSourceFactory implements ConfigSourceFactory {
                 }
             }
         });
+    }
+
+    private static boolean hasPropertyWithPrefix(ConfigSourceContext context, Map<String, String> properties, String prefix) {
+        if (properties.keySet().stream().anyMatch(name -> name.startsWith(prefix))) {
+            return true;
+        }
+
+        Iterator<String> names = context.iterateNames();
+        while (names.hasNext()) {
+            String name = names.next();
+            ConfigValue value = context.getValue(name);
+            if (value != null && value.getValue() != null && name.startsWith(prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static class DebeziumServerConfigSource extends MapBackedConfigSource {

--- a/debezium-server-core/src/test/java/io/debezium/server/configuration/DebeziumServerConfigSourceFactoryTest.java
+++ b/debezium-server-core/src/test/java/io/debezium/server/configuration/DebeziumServerConfigSourceFactoryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigValue;
+
+/**
+ * Unit tests for the reuse of the sink connection properties for the schema history and offset
+ * storage namespaces in {@link DebeziumServerConfigSourceFactory}.
+ *
+ * @author Mahitha Adapa
+ */
+public class DebeziumServerConfigSourceFactoryTest {
+
+    @Test
+    public void shouldReuseSinkPropertiesForStorageWhenStorageNotConfigured() {
+        Map<String, String> result = remap(Map.of(
+                "debezium.sink.type", "redis",
+                "debezium.sink.redis.address", "localhost:6379"));
+
+        assertThat(result).containsEntry("quarkus.debezium.schema.history.internal.redis.address", "localhost:6379");
+        assertThat(result).containsEntry("quarkus.debezium.offset.storage.redis.address", "localhost:6379");
+    }
+
+    @Test
+    public void shouldNotReuseSinkPropertiesWhenSchemaHistoryConfiguredExplicitly() {
+        Map<String, String> result = remap(Map.of(
+                "debezium.sink.type", "redis",
+                "debezium.sink.redis.connection.url", "sink-host:6379",
+                "debezium.sink.redis.batch.size", "1000",
+                "debezium.source.schema.history.internal.redis.url", "history-host:6379"));
+
+        // Explicit config is kept and sink properties with different names do not leak into the namespace.
+        assertThat(result).containsEntry("quarkus.debezium.schema.history.internal.redis.url", "history-host:6379");
+        assertThat(result).doesNotContainKey("quarkus.debezium.schema.history.internal.redis.connection.url");
+        assertThat(result).doesNotContainKey("quarkus.debezium.schema.history.internal.redis.batch.size");
+        // The guard is namespace-specific: offset storage is still reused.
+        assertThat(result).containsEntry("quarkus.debezium.offset.storage.redis.connection.url", "sink-host:6379");
+    }
+
+    @Test
+    public void shouldNotReuseSinkPropertiesWhenSchemaHistoryConfiguredExplicitlyWithQuarkusNamespace() {
+        Map<String, String> result = remap(Map.of(
+                "debezium.sink.type", "redis",
+                "debezium.sink.redis.connection.url", "sink-host:6379",
+                "debezium.sink.redis.batch.size", "1000",
+                "quarkus.debezium.schema.history.internal.redis.url", "history-host:6379"));
+
+        assertThat(result).containsEntry("debezium.source.schema.history.internal.redis.url", "history-host:6379");
+        assertThat(result).doesNotContainKey("quarkus.debezium.schema.history.internal.redis.connection.url");
+        assertThat(result).doesNotContainKey("quarkus.debezium.schema.history.internal.redis.batch.size");
+        // The guard is namespace-specific: offset storage is still reused.
+        assertThat(result).containsEntry("quarkus.debezium.offset.storage.redis.connection.url", "sink-host:6379");
+    }
+
+    @Test
+    public void shouldNotReuseSinkPropertiesWhenOffsetStorageConfiguredExplicitly() {
+        Map<String, String> result = remap(Map.of(
+                "debezium.sink.type", "redis",
+                "debezium.sink.redis.address", "sink-host:6379",
+                "debezium.sink.redis.batch.size", "1000",
+                "debezium.source.offset.storage.redis.address", "offset-host:6379"));
+
+        assertThat(result).containsEntry("quarkus.debezium.offset.storage.redis.address", "offset-host:6379");
+        assertThat(result).doesNotContainKey("quarkus.debezium.offset.storage.redis.batch.size");
+        // The guard is namespace-specific: schema history is still reused.
+        assertThat(result).containsEntry("quarkus.debezium.schema.history.internal.redis.address", "sink-host:6379");
+    }
+
+    private static Map<String, String> remap(Map<String, String> input) {
+        Map<String, String> result = new HashMap<>();
+        new DebeziumServerConfigSourceFactory().getConfigSources(new MapConfigSourceContext(input))
+                .forEach(source -> result.putAll(source.getProperties()));
+        return result;
+    }
+
+    /**
+     * Minimal {@link ConfigSourceContext} backed by a fixed map, so the factory can be exercised
+     * without the full MicroProfile Config runtime.
+     */
+    private static final class MapConfigSourceContext implements ConfigSourceContext {
+
+        private final Map<String, String> properties;
+
+        MapConfigSourceContext(Map<String, String> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public ConfigValue getValue(String name) {
+            return ConfigValue.builder().withName(name).withValue(properties.get(name)).build();
+        }
+
+        @Override
+        public Iterator<String> iterateNames() {
+            return properties.keySet().iterator();
+        }
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2078

## Problem
Debezium Server reuses the `debezium.sink.<type>.*` connection properties for the schema history and offset storage namespaces. The remapping runs unconditionally and is only guarded per-key by `overwrite=false`, so when the sink and storage use different property names for the same concept the sink values can silently override explicit storage configuration, and unrelated sink properties leak into the storage namespaces.

## Fix
Skip the sink-to-storage remapping for a namespace once it has been configured explicitly; the convenience behavior is unchanged when no explicit storage configuration is present. The logic now lives in `DebeziumServerConfigSourceFactory` (moved from `DebeziumServer.java` in debezium/dbz#1731).

## Testing
Added a unit test for `DebeziumServerConfigSourceFactory` covering the reuse and skip paths (no Docker); it fails before the fix and passes after.
