### PR TITLE
debezium/dbz#2225 Support MessageGroupId on standard SNS topics for SQS fair queues

### DIFF
--- a/debezium-server-sns/src/main/java/io/debezium/server/sns/SnsChangeConsumer.java
+++ b/debezium-server-sns/src/main/java/io/debezium/server/sns/SnsChangeConsumer.java
@@ -218,15 +218,20 @@ public class SnsChangeConsumer extends BaseChangeConsumer implements DebeziumSer
             builder.messageAttributes(attributes);
         }
 
-        if (isFifo) {
-            // MessageGroupId: use header value if present, fallback to raw event key, then default
+        // MessageGroupId: set for FIFO topics (message ordering) or, when explicitly enabled, for standard
+        // topics as well (Amazon SQS fair-queue tenant identifier — no ordering on standard topics).
+        if (isFifo || config.isMessageGroupIdEnabled()) {
+            // use header value if present, fallback to raw event key, then default
             String groupId = headers.getOrDefault(config.getMessageGroupIdHeader(), null);
             if (groupId == null) {
                 Object rawKey = event.record().key();
-                groupId = rawKey != null ? asString(rawKey) : config.getFifoDefaultGroupId();
+                groupId = rawKey != null ? asString(rawKey) : config.getDefaultMessageGroupId();
             }
             builder.messageGroupId(groupId);
+        }
 
+        // MessageDeduplicationId applies only to FIFO topics
+        if (isFifo) {
             // MessageDeduplicationId: use header if configured and present
             if (config.getMessageDeduplicationIdHeader() != null) {
                 String dedupId = headers.get(config.getMessageDeduplicationIdHeader());
@@ -315,9 +320,10 @@ public class SnsChangeConsumer extends BaseChangeConsumer implements DebeziumSer
                 SnsChangeConsumerConfig.TOPIC_ARN,
                 SnsChangeConsumerConfig.TOPIC_ARN_PREFIX,
                 SnsChangeConsumerConfig.DEFAULT_RETRIES,
-                SnsChangeConsumerConfig.FIFO_MESSAGE_GROUP_ID_HEADER,
-                SnsChangeConsumerConfig.FIFO_MESSAGE_DEDUP_ID_HEADER,
-                SnsChangeConsumerConfig.FIFO_DEFAULT_GROUP_ID);
+                SnsChangeConsumerConfig.MESSAGE_GROUP_ID_HEADER,
+                SnsChangeConsumerConfig.MESSAGE_GROUP_ID_DEFAULT,
+                SnsChangeConsumerConfig.MESSAGE_GROUP_ID_ENABLED,
+                SnsChangeConsumerConfig.FIFO_MESSAGE_DEDUP_ID_HEADER);
     }
 
     @Override

--- a/debezium-server-sns/src/main/java/io/debezium/server/sns/SnsChangeConsumerConfig.java
+++ b/debezium-server-sns/src/main/java/io/debezium/server/sns/SnsChangeConsumerConfig.java
@@ -6,6 +6,8 @@
 package io.debezium.server.sns;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
@@ -14,6 +16,8 @@ import io.debezium.config.Field;
  * Configuration fields for {@link SnsChangeConsumer}.
  */
 public class SnsChangeConsumerConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SnsChangeConsumerConfig.class);
 
     public static final int MAX_BATCH_SIZE = 10;
     public static final int DEFAULT_RETRY_COUNT = 5;
@@ -62,13 +66,15 @@ public class SnsChangeConsumerConfig {
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("Maximum number of retry attempts for failed requests.");
 
-    public static final Field FIFO_MESSAGE_GROUP_ID_HEADER = Field.create("fifo.message.group.id.header")
-            .withDisplayName("FIFO Message Group ID Header")
+    public static final Field MESSAGE_GROUP_ID_HEADER = Field.create("message.group.id.header")
+            .withDisplayName("Message Group ID Header")
             .withType(ConfigDef.Type.STRING)
             .withDefault("aggregateId")
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
-            .withDescription("Header name to use as the MessageGroupId for FIFO topics.");
+            .withDeprecatedAliases("fifo.message.group.id.header")
+            .withDescription("Header name to use as the MessageGroupId. Applies to FIFO topics, and to standard "
+                    + "topics when 'message.group.id.enabled' is true.");
 
     public static final Field FIFO_MESSAGE_DEDUP_ID_HEADER = Field.create("fifo.message.dedup.id.header")
             .withDisplayName("FIFO Message Deduplication ID Header")
@@ -77,13 +83,28 @@ public class SnsChangeConsumerConfig {
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("Header name to use as the MessageDeduplicationId for FIFO topics.");
 
-    public static final Field FIFO_DEFAULT_GROUP_ID = Field.create("fifo.default.group.id")
-            .withDisplayName("FIFO Default Group ID")
+    public static final Field MESSAGE_GROUP_ID_DEFAULT = Field.create("message.group.id.default")
+            .withDisplayName("Default Message Group ID")
             .withType(ConfigDef.Type.STRING)
             .withDefault("default")
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
-            .withDescription("Default MessageGroupId when no header value is found for FIFO topics.");
+            .withDeprecatedAliases("fifo.default.group.id")
+            .withDescription("Default MessageGroupId when neither a header value nor a record key is found. Applies "
+                    + "to FIFO topics, and to standard topics when 'message.group.id.enabled' is true.");
+
+    public static final Field MESSAGE_GROUP_ID_ENABLED = Field.create("message.group.id.enabled")
+            .withDisplayName("Message Group ID Enabled")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withDefault(false)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("When true, set MessageGroupId on standard (non-FIFO) topics as well, to enable Amazon SQS "
+                    + "fair queues on subscribed standard queues. On standard topics MessageGroupId is a tenant "
+                    + "identifier for fairness and does not enforce ordering. The value is resolved the same way as for "
+                    + "FIFO topics: from the header configured by '" + MESSAGE_GROUP_ID_HEADER.name() + "', falling "
+                    + "back to the record key, then '" + MESSAGE_GROUP_ID_DEFAULT.name() + "'. FIFO topics are "
+                    + "unaffected. Defaults to false, preserving existing behavior.");
 
     // Instance fields
     private String region;
@@ -94,7 +115,8 @@ public class SnsChangeConsumerConfig {
     private int maxRetries;
     private String messageGroupIdHeader;
     private String messageDeduplicationIdHeader;
-    private String fifoDefaultGroupId;
+    private String defaultMessageGroupId;
+    private boolean messageGroupIdEnabled;
 
     public SnsChangeConsumerConfig(Configuration config) {
         init(config);
@@ -107,9 +129,23 @@ public class SnsChangeConsumerConfig {
         topicArn = config.getString(TOPIC_ARN);
         topicArnPrefix = config.getString(TOPIC_ARN_PREFIX);
         maxRetries = config.getInteger(DEFAULT_RETRIES);
-        messageGroupIdHeader = config.getString(FIFO_MESSAGE_GROUP_ID_HEADER);
+        messageGroupIdHeader = config.getString(MESSAGE_GROUP_ID_HEADER);
         messageDeduplicationIdHeader = config.getString(FIFO_MESSAGE_DEDUP_ID_HEADER);
-        fifoDefaultGroupId = config.getString(FIFO_DEFAULT_GROUP_ID);
+        defaultMessageGroupId = config.getString(MESSAGE_GROUP_ID_DEFAULT);
+        messageGroupIdEnabled = config.getBoolean(MESSAGE_GROUP_ID_ENABLED);
+        warnIfDeprecatedAliasUsed(config, MESSAGE_GROUP_ID_HEADER);
+        warnIfDeprecatedAliasUsed(config, MESSAGE_GROUP_ID_DEFAULT);
+    }
+
+    private static void warnIfDeprecatedAliasUsed(Configuration config, Field field) {
+        if (config.hasKey(field.name())) {
+            return;
+        }
+        for (String alias : field.deprecatedAliases()) {
+            if (config.hasKey(alias)) {
+                LOGGER.warn("Configuration property '{}' is deprecated, use '{}' instead.", alias, field.name());
+            }
+        }
     }
 
     public String getRegion() {
@@ -144,7 +180,11 @@ public class SnsChangeConsumerConfig {
         return messageDeduplicationIdHeader;
     }
 
-    public String getFifoDefaultGroupId() {
-        return fifoDefaultGroupId;
+    public String getDefaultMessageGroupId() {
+        return defaultMessageGroupId;
+    }
+
+    public boolean isMessageGroupIdEnabled() {
+        return messageGroupIdEnabled;
     }
 }

--- a/debezium-server-sns/src/test/java/io/debezium/server/sns/SnsChangeConsumerConfigTest.java
+++ b/debezium-server-sns/src/test/java/io/debezium/server/sns/SnsChangeConsumerConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.sns;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+/**
+ * Unit tests for {@link SnsChangeConsumerConfig}, covering the neutral {@code message.group.id.*}
+ * properties and their deprecated {@code fifo.*} aliases.
+ */
+public class SnsChangeConsumerConfigTest {
+
+    @Test
+    public void testMessageGroupIdHeaderResolvedFromNewProperty() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.of("message.group.id.header", "tenantId")));
+        assertEquals("tenantId", config.getMessageGroupIdHeader());
+    }
+
+    @Test
+    public void testMessageGroupIdHeaderResolvedFromDeprecatedAlias() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.of("fifo.message.group.id.header", "legacyHeader")));
+        assertEquals("legacyHeader", config.getMessageGroupIdHeader());
+    }
+
+    @Test
+    public void testMessageGroupIdHeaderNewPropertyWinsOverDeprecatedAlias() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(Configuration.from(Map.of(
+                "message.group.id.header", "newHeader",
+                "fifo.message.group.id.header", "legacyHeader")));
+        assertEquals("newHeader", config.getMessageGroupIdHeader());
+    }
+
+    @Test
+    public void testDefaultMessageGroupIdResolvedFromNewProperty() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.of("message.group.id.default", "shared-tenant")));
+        assertEquals("shared-tenant", config.getDefaultMessageGroupId());
+    }
+
+    @Test
+    public void testDefaultMessageGroupIdResolvedFromDeprecatedAlias() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.of("fifo.default.group.id", "legacy-group")));
+        assertEquals("legacy-group", config.getDefaultMessageGroupId());
+    }
+
+    @Test
+    public void testDefaultMessageGroupIdNewPropertyWinsOverDeprecatedAlias() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(Configuration.from(Map.of(
+                "message.group.id.default", "new-group",
+                "fifo.default.group.id", "legacy-group")));
+        assertEquals("new-group", config.getDefaultMessageGroupId());
+    }
+
+    @Test
+    public void testMessageGroupIdDisabledByDefault() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.<String, String> of()));
+        assertFalse(config.isMessageGroupIdEnabled());
+    }
+
+    @Test
+    public void testGroupIdPropertiesFallBackToDefaults() {
+        SnsChangeConsumerConfig config = new SnsChangeConsumerConfig(
+                Configuration.from(Map.<String, String> of()));
+        assertEquals("aggregateId", config.getMessageGroupIdHeader());
+        assertEquals("default", config.getDefaultMessageGroupId());
+    }
+}

--- a/debezium-server-sns/src/test/java/io/debezium/server/sns/SnsUnitTest.java
+++ b/debezium-server-sns/src/test/java/io/debezium/server/sns/SnsUnitTest.java
@@ -7,6 +7,7 @@ package io.debezium.server.sns;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.config.Configuration;
 import io.debezium.engine.Header;
 import io.debezium.runtime.BatchEvent;
 import io.debezium.runtime.CapturingEvents;
@@ -837,5 +839,190 @@ public class SnsUnitTest {
         assertFalse(threwException.get());
         assertEquals(1, capturedEntries.size());
         assertEquals("order-42", capturedEntries.get(0).messageGroupId());
+    }
+
+    private static CapturingEvents<BatchEvent> capturingEvents(List<BatchEvent> events, String destination) {
+        return new CapturingEvents<>() {
+            @Override
+            public List<BatchEvent> records() {
+                return events;
+            }
+
+            @Override
+            public String destination() {
+                return destination;
+            }
+
+            @Override
+            public String source() {
+                return "";
+            }
+
+            @Override
+            public String engine() {
+                return "";
+            }
+        };
+    }
+
+    // 13. Test that on a STANDARD topic, MessageGroupId is set from the header when message.group.id.enabled=true
+    @Test
+    public void testStandardTopicMessageGroupIdFromHeaderWhenEnabled() throws Exception {
+        // Arrange
+        String standardArn = TEST_DEFAULT_TOPIC_ARN; // no .fifo suffix
+        List<BatchEvent> events = createFifoChangeEvents(1, "some-key", "some-key", standardArn, Map.of("aggregateId", "tenant-7"));
+
+        List<PublishBatchRequestEntry> capturedEntries = new ArrayList<>();
+        doAnswer(invocation -> {
+            PublishBatchRequest request = invocation.getArgument(0);
+            capturedEntries.addAll(request.publishBatchRequestEntries());
+            return successResponse(request);
+        }).when(spyClient).publishBatch(any(PublishBatchRequest.class));
+
+        // Act — connect() wires the mocked client; inject config explicitly so the test is
+        // deterministic and independent of global System properties
+        try {
+            snsChangeConsumer.connect();
+            snsChangeConsumer.config = new SnsChangeConsumerConfig(
+                    Configuration.from(Map.of(SnsChangeConsumerConfig.MESSAGE_GROUP_ID_ENABLED.name(), "true")));
+            snsChangeConsumer.handle(capturingEvents(events, standardArn));
+        }
+        catch (Exception e) {
+            threwException.getAndSet(true);
+        }
+
+        // Assert
+        assertFalse(threwException.get());
+        assertEquals(1, capturedEntries.size());
+        assertEquals("tenant-7", capturedEntries.get(0).messageGroupId());
+    }
+
+    // 14. Test that on a STANDARD topic with the flag enabled, MessageGroupId falls back to the raw key when no header
+    @Test
+    public void testStandardTopicMessageGroupIdFallsBackToKeyWhenEnabled() throws Exception {
+        // Arrange
+        String standardArn = TEST_DEFAULT_TOPIC_ARN;
+        List<BatchEvent> events = createFifoChangeEvents(1, "tenant-key", "tenant-key", standardArn, Map.of());
+
+        List<PublishBatchRequestEntry> capturedEntries = new ArrayList<>();
+        doAnswer(invocation -> {
+            PublishBatchRequest request = invocation.getArgument(0);
+            capturedEntries.addAll(request.publishBatchRequestEntries());
+            return successResponse(request);
+        }).when(spyClient).publishBatch(any(PublishBatchRequest.class));
+
+        // Act — inject config with the flag enabled (see note above re: explicit config injection)
+        try {
+            snsChangeConsumer.connect();
+            snsChangeConsumer.config = new SnsChangeConsumerConfig(
+                    Configuration.from(Map.of(SnsChangeConsumerConfig.MESSAGE_GROUP_ID_ENABLED.name(), "true")));
+            snsChangeConsumer.handle(capturingEvents(events, standardArn));
+        }
+        catch (Exception e) {
+            threwException.getAndSet(true);
+        }
+
+        // Assert
+        assertFalse(threwException.get());
+        assertEquals(1, capturedEntries.size());
+        assertEquals("tenant-key", capturedEntries.get(0).messageGroupId());
+    }
+
+    // 15. Test backward compatibility: on a STANDARD topic with the flag OFF (default), no MessageGroupId is set
+    @Test
+    public void testStandardTopicNoMessageGroupIdByDefault() throws Exception {
+        // Arrange
+        String standardArn = TEST_DEFAULT_TOPIC_ARN;
+        List<BatchEvent> events = createFifoChangeEvents(1, "tenant-key", "tenant-key", standardArn, Map.of("aggregateId", "tenant-7"));
+
+        List<PublishBatchRequestEntry> capturedEntries = new ArrayList<>();
+        doAnswer(invocation -> {
+            PublishBatchRequest request = invocation.getArgument(0);
+            capturedEntries.addAll(request.publishBatchRequestEntries());
+            return successResponse(request);
+        }).when(spyClient).publishBatch(any(PublishBatchRequest.class));
+
+        // Act — inject an explicit empty config so the flag defaults to false
+        try {
+            snsChangeConsumer.connect();
+            snsChangeConsumer.config = new SnsChangeConsumerConfig(Configuration.from(Map.<String, String> of()));
+            snsChangeConsumer.handle(capturingEvents(events, standardArn));
+        }
+        catch (Exception e) {
+            threwException.getAndSet(true);
+        }
+
+        // Assert
+        assertFalse(threwException.get());
+        assertEquals(1, capturedEntries.size());
+        assertNull(capturedEntries.get(0).messageGroupId());
+    }
+
+    // 16. Regression: with message.group.id.enabled=true, a FIFO topic still sets BOTH MessageGroupId and
+    // MessageDeduplicationId (the flag must not change FIFO behavior — it only adds the standard-topic path)
+    @Test
+    public void testFifoUnaffectedWhenStandardFlagEnabled() throws Exception {
+        // Arrange
+        String fifoArn = "arn:aws:sns:us-east-1:000000000000:test-topic.fifo";
+        List<BatchEvent> events = createFifoChangeEvents(1, "some-key", "some-key", fifoArn,
+                Map.of("aggregateId", "order-77", "dedupId", "dd-1"));
+
+        List<PublishBatchRequestEntry> capturedEntries = new ArrayList<>();
+        doAnswer(invocation -> {
+            PublishBatchRequest request = invocation.getArgument(0);
+            capturedEntries.addAll(request.publishBatchRequestEntries());
+            return successResponse(request);
+        }).when(spyClient).publishBatch(any(PublishBatchRequest.class));
+
+        // Act — topic is FIFO; inject config with the dedup-id header (flag on too, to prove it
+        // doesn't disturb FIFO)
+        try {
+            snsChangeConsumer.connect();
+            snsChangeConsumer.config = new SnsChangeConsumerConfig(Configuration.from(Map.of(
+                    SnsChangeConsumerConfig.MESSAGE_GROUP_ID_ENABLED.name(), "true",
+                    SnsChangeConsumerConfig.FIFO_MESSAGE_DEDUP_ID_HEADER.name(), "dedupId")));
+            snsChangeConsumer.handle(capturingEvents(events, fifoArn));
+        }
+        catch (Exception e) {
+            threwException.getAndSet(true);
+        }
+
+        // Assert — FIFO behavior intact: both group id and dedup id set
+        assertFalse(threwException.get());
+        assertEquals(1, capturedEntries.size());
+        assertEquals("order-77", capturedEntries.get(0).messageGroupId());
+        assertEquals("dd-1", capturedEntries.get(0).messageDeduplicationId());
+    }
+
+    // 17. Test that on a STANDARD topic with the flag enabled, MessageGroupId falls back to the default
+    // group id when there is no header and no record key (non-FIFO equivalent of test 11)
+    @Test
+    public void testStandardTopicMessageGroupIdFallsBackToDefaultWhenEnabled() throws Exception {
+        // Arrange
+        String standardArn = TEST_DEFAULT_TOPIC_ARN;
+        List<BatchEvent> events = createFifoChangeEvents(1, null, null, standardArn, Map.of());
+
+        List<PublishBatchRequestEntry> capturedEntries = new ArrayList<>();
+        doAnswer(invocation -> {
+            PublishBatchRequest request = invocation.getArgument(0);
+            capturedEntries.addAll(request.publishBatchRequestEntries());
+            return successResponse(request);
+        }).when(spyClient).publishBatch(any(PublishBatchRequest.class));
+
+        // Act — inject config with the flag enabled (see note above re: explicit config injection)
+        try {
+            snsChangeConsumer.connect();
+            snsChangeConsumer.config = new SnsChangeConsumerConfig(
+                    Configuration.from(Map.of(SnsChangeConsumerConfig.MESSAGE_GROUP_ID_ENABLED.name(), "true")));
+            snsChangeConsumer.handle(capturingEvents(events, standardArn));
+        }
+        catch (Exception e) {
+            threwException.getAndSet(true);
+        }
+
+        // Assert
+        assertFalse(threwException.get());
+        assertEquals(1, capturedEntries.size());
+        assertEquals("default", capturedEntries.get(0).messageGroupId());
     }
 }


### PR DESCRIPTION
## What

Adds an opt-in `debezium.sink.sns.message.group.id.enabled` (default `false`) that lets the SNS sink set `MessageGroupId` on **standard** (non-FIFO) topics, enabling [Amazon SQS fair queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html) on subscribed standard queues.

## Why

Since 2025, `MessageGroupId` on a **standard** SQS queue acts as a *tenant identifier* for fair-queue noisy-neighbor mitigation (it does **not** enforce ordering there — that stays FIFO-only), and [SNS standard topics forward `MessageGroupId`](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html) to subscribed standard SQS queues. Today the SNS sink only sets `MessageGroupId` when the topic ARN ends in `.fifo`, so a CDC → SNS → standard-SQS pipeline can't get per-tenant fairness. This closes that gap.

## Change

- New config `message.group.id.enabled` (boolean, default `false`).
- When `true`, `MessageGroupId` is resolved for standard topics the **same way as FIFO** — from the group-id header, falling back to the record key, then the configured default.
- **Neutral config namespace (per review):** the group-id resolution properties are now `message.group.id.header` and `message.group.id.default`. The former `fifo.message.group.id.header` and `fifo.default.group.id` are registered as **deprecated aliases** (`Field.withDeprecatedAliases`) — existing configs keep working, with a deprecation warning logged when an alias key is used and the new key takes precedence when both are set. `fifo.message.dedup.id.header` is intentionally unchanged, as `MessageDeduplicationId` is FIFO-only (invalid on standard topics).
- **FIFO topics are unaffected** (they always set `MessageGroupId`, as before).
- Default `false` preserves existing behavior for all current standard-topic users.

## Tests

Behavior (SnsUnitTest):
- standard topic + flag on → resolves `MessageGroupId` from the header,
- standard topic + flag on → falls back to the record key when no header,
- standard topic + flag on → falls back to `message.group.id.default` when no header and no key,
- standard topic + flag **off** (default) → sets **no** `MessageGroupId` (backward compatibility),
- **FIFO regression** → with the flag on, a FIFO topic still sets **both** `MessageGroupId` and `MessageDeduplicationId`.

Config resolution (SnsChangeConsumerConfigTest):
- new keys resolve; deprecated `fifo.*` aliases still resolve,
- new key wins when both old and new are set (both properties),
- defaults hold (`aggregateId` / `default`), and the flag defaults to `false`.

## Notes

- **Behavior note:** on a standard topic with the flag on, a record with no header and no key resolves to `message.group.id.default` (`"default"`), i.e. one shared tenant bucket. That's opt-in-by-design (provide a key/header for real per-tenant fairness); documented in the config description.
- **Docs:** a config-reference PR in `debezium/debezium` will follow — I'll link it here.
- **Scope:** SNS sink only. Extending the SQS *direct* sink to a dynamic per-message group id is a separately scoped follow-up, per review discussion.

Closes debezium/dbz#2225
