### PR TITLE
debezium/dbz#2317 Allow case-insensitive config property matching

### DIFF
--- a/debezium-server-core/src/main/java/io/debezium/server/BaseChangeConsumer.java
+++ b/debezium-server-core/src/main/java/io/debezium/server/BaseChangeConsumer.java
@@ -9,6 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.inject.Instance;
@@ -19,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
 import io.debezium.engine.Header;
 import io.debezium.runtime.BatchEvent;
 
@@ -65,6 +68,39 @@ public class BaseChangeConsumer {
         }
 
         return ret;
+    }
+
+    /**
+     * Get a {@link Configuration} instance from a subset of the MicroProfile configuration properties
+     * that matches the given prefix. The resulting configuration performs case-insensitive key lookups,
+     * which is necessary because MicroProfile Config maps environment variable names to all-lowercase
+     * property names, while Debezium field definitions may use camelCase.
+     *
+     * @param config    The global MicroProfile configuration object.
+     * @param prefix    The prefix to filter property names.
+     *
+     * @return          A case-insensitive {@link Configuration} containing property names without
+     *                  the prefix; never null.
+     */
+    protected Configuration getConfiguration(Config config, String prefix) {
+        final TreeMap<String, String> props = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (String propertyName : config.getPropertyNames()) {
+            if (propertyName.startsWith(prefix)) {
+                final String newPropertyName = propertyName.substring(prefix.length());
+                props.put(newPropertyName, config.getConfigValue(propertyName).getValue());
+            }
+        }
+        return new Configuration() {
+            @Override
+            public String getString(String key) {
+                return props.get(key);
+            }
+
+            @Override
+            public Set<String> keys() {
+                return props.keySet();
+            }
+        };
     }
 
     protected byte[] getBytes(Object object) {

--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumer.java
@@ -88,8 +88,7 @@ public class RabbitMqStreamChangeConsumer extends BaseChangeConsumer implements 
         final Config mpConfig = ConfigProvider.getConfig();
 
         // Load configuration
-        io.debezium.config.Configuration configuration = io.debezium.config.Configuration.from(getConfigSubset(mpConfig, PROP_PREFIX));
-        this.config = new RabbitMqStreamChangeConsumerConfig(configuration);
+        this.config = new RabbitMqStreamChangeConsumerConfig(getConfiguration(mpConfig, PROP_PREFIX));
 
         ConnectionFactory factory = new ConnectionFactory();
         Map<String, String> configProperties = getConfigSubset(mpConfig, PROP_CONNECTION_PREFIX).entrySet().stream()

--- a/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
+++ b/debezium-server-rabbitmq/src/main/java/io/debezium/server/rabbitmq/RabbitMqStreamNativeChangeConsumer.java
@@ -168,8 +168,7 @@ public class RabbitMqStreamNativeChangeConsumer extends BaseChangeConsumer imple
         final Config mpConfig = ConfigProvider.getConfig();
 
         // Load configuration
-        io.debezium.config.Configuration configuration = io.debezium.config.Configuration.from(getConfigSubset(mpConfig, PROP_PREFIX));
-        this.config = new RabbitMqStreamNativeChangeConsumerConfig(configuration);
+        this.config = new RabbitMqStreamNativeChangeConsumerConfig(getConfiguration(mpConfig, PROP_PREFIX));
 
         if (config.getConnectionHost() != null || config.getConnectionPort() != null) {
             LOGGER.warn("The parameters connection.host and connection.port are deprecated, please use rabbitmqstream.host and rabbitmqstream.port moving forward.");

--- a/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumerTest.java
+++ b/debezium-server-rabbitmq/src/test/java/io/debezium/server/rabbitmq/RabbitMqStreamChangeConsumerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
@@ -27,6 +29,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine.RecordCommitter;
 import io.debezium.runtime.BatchEvent;
@@ -102,6 +106,58 @@ class RabbitMqStreamChangeConsumerTest {
         when(streamNameMapperMock.map(topicName)).thenReturn(topicName);
 
         rabbitMqStreamChangeConsumer.config = createConfig(DELIVERY_MODE, ACK_TIMEOUT, topicName, "topic", "ignored", true, true);
+
+        // when
+        rabbitMqStreamChangeConsumer.handle(records);
+
+        // then
+        verify(channelMock).queueDeclare(topicName, true, false, false, null);
+
+        final AMQP.BasicProperties expectedProperties = new AMQP.BasicProperties.Builder()
+                .deliveryMode(DELIVERY_MODE)
+                .headers(Map.of())
+                .build();
+
+        verify(channelMock).basicPublish(topicName, topicName, expectedProperties, payload.getBytes());
+        verify(channelMock).waitForConfirmsOrDie(ACK_TIMEOUT);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2317")
+    void testHandleBatchTopicRoutingKeySourceFromEnvironmentVariable() throws InterruptedException, IOException, TimeoutException {
+        // given
+        String topicName = "test-topic";
+        String payload = "test content";
+        CapturingEvents<BatchEvent> records = createCapturingEvents(topicName, eventMock);
+
+        when(eventMock.value()).thenReturn(payload);
+        when(eventMock.headers()).thenReturn(List.of());
+        when(eventMock.destination()).thenReturn(topicName);
+        when(streamNameMapperMock.map(topicName)).thenReturn(topicName);
+
+        // Simulate environment variable mapping where property names are all lowercase
+        TreeMap<String, String> props = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        props.put("deliverymode", String.valueOf(DELIVERY_MODE));
+        props.put("acktimeout", String.valueOf(ACK_TIMEOUT));
+        props.put("exchange", topicName);
+        props.put("routingkey.source", "topic");
+        props.put("routingkey", "ignored");
+        props.put("autocreateroutingkey", "true");
+        props.put("routingkeydurable", "true");
+        props.put("routingkeyfromtopicname", "false");
+        props.put("null.value", "default");
+        Configuration configuration = new Configuration() {
+            @Override
+            public String getString(String key) {
+                return props.get(key);
+            }
+
+            @Override
+            public Set<String> keys() {
+                return props.keySet();
+            }
+        };
+        rabbitMqStreamChangeConsumer.config = new RabbitMqStreamChangeConsumerConfig(configuration);
 
         // when
         rabbitMqStreamChangeConsumer.handle(records);


### PR DESCRIPTION
Fixes debezium/dbz#2317

## Description

In Debezium 3.3, the RabbitMQ sink used MicroProfile to map settings like `routingKey.source`. When using MicroProfile, it was able to reconcile the environment variable configuration-based approach to the property directly. However, since we consolidated this in debezium/dbz#1668, the RabbitMQ connector configuration that worked throughout 3.1 through 3.5 no longer works in 3.6+.

What this PR introduces is a specialization that reads the supplied configuration, and even though the property keys are stored in lowercase, it applies a case-insensitive lookup, which allows the `routingKey.source` lookup to succeed.

## Question

This is currently only applied to RabbitMQ; however, I could imagine we might want to extend this to others. I'll leave that as a discussion item on the PR to decide what the scope of this change should be.

## Backports

If accepted, this should be backported to 3.6 to restore old behavior.