### PR TITLE
debezium/dbz#2318 Add Db2 to the Debezium Server assembly distribution profile

### DIFF
--- a/debezium-server-dist/pom.xml
+++ b/debezium-server-dist/pom.xml
@@ -381,6 +381,11 @@
                 </dependency>
                 <dependency>
                     <groupId>io.debezium.quarkus</groupId>
+                    <artifactId>debezium-quarkus-db2</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium.quarkus</groupId>
                     <artifactId>debezium-quarkus-oracle</artifactId>
                     <version>${project.version}</version>
                 </dependency>


### PR DESCRIPTION
Adds the `debezium-quarkus-db2` engine extension to the Debezium Server `assembly`
distribution profile, so a distribution built with the default `assembly` profile can run
a Db2 source out of the box — consistent with the other bundled connectors.

## What

`debezium-server-dist/pom.xml` — the `assembly` profile bundles the Quarkus engine
extensions for mariadb, mysql, postgres, mongodb, sqlserver and oracle, but was missing
`debezium-quarkus-db2`. The sibling `assembly-prod` profile already includes it, so the
two profiles were inconsistent and Db2 was the only connector absent from `assembly`.

This adds the single missing dependency, matching `assembly-prod`.

## Why

Without it, a Debezium Server distribution built with the `assembly` profile has no Db2
Quarkus engine, so a Db2 source cannot start without manually adding the artifact.

## Notes

- Found while validating Db2 as a source for the Databricks Zerobus sink
  (debezium/dbz#2279); the issue is not Zerobus-specific.
- Packaging only — distinct from the Db2/MongoDB Quarkus engine bootstrap defects in
  debezium/dbz#2284.
- 3.7 only: `debezium-quarkus-db2` does not exist on the 3.6 branch, so no backport is
  needed.

Fixes debezium/dbz#2318
