### PR TITLE
debezium/dbz#2343 Add missing storage dependencies

### DIFF
--- a/debezium-server-core/pom.xml
+++ b/debezium-server-core/pom.xml
@@ -74,6 +74,16 @@
             <artifactId>debezium-openlineage-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-storage-api</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-storage-common</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>io.debezium</groupId>


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/2343

This seems to be the best option - `debezium-storage-api` and `debezium-storage-common` are used by several other storage modules, so it's not good to bundle them in these modules multiple time. Add them as a dependency into `debezium-server-code` so that they are available to all other server modules without need to declare them in all the modules.