### PR TITLE
debezium/dbz#2386 Upgrade AWS SDK v2 (Kinesis, SQS, SNS) to 2.53.1

### DIFF
--- a/debezium-server-bom/pom.xml
+++ b/debezium-server-bom/pom.xml
@@ -12,9 +12,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.kinesis>2.17.241</version.kinesis>
-        <version.sqs>2.13.13</version.sqs>
-        <version.sns>2.17.241</version.sns>
+        <version.kinesis>2.53.1</version.kinesis>
+        <version.sqs>2.53.1</version.sqs>
+        <version.sns>2.53.1</version.sns>
         <version.pubsub>26.74.0</version.pubsub>
         <version.pulsar>4.2.1</version.pulsar>
         <version.milvus>2.5.4</version.milvus>


### PR DESCRIPTION
Fixes debezium/dbz#2386
Fixes debezium/dbz#1738

## Description
Align the AWS messaging SDK versions in the server BOM to `2.53.1`:

- `version.kinesis` `2.17.241` → `2.53.1`
- `version.sqs` `2.13.13` → `2.53.1`
- `version.sns` `2.17.241` → `2.53.1`

This keeps the Kinesis, SQS, and SNS AWS SDK v2 modules on a single, consistent
version and in line with the S3 SDK upgrade (`2.53.1`).

Changes:
- `debezium-server-bom/pom.xml`: bump `version.kinesis`, `version.sqs`, and
  `version.sns` to `2.53.1`
